### PR TITLE
ci(renovate): switch back to `@scaleway/changesets-renovate`

### DIFF
--- a/.github/workflows/renovate-changeset.yaml
+++ b/.github/workflows/renovate-changeset.yaml
@@ -54,13 +54,12 @@ jobs:
 
       - id: renovate-changesets
         name: Generate Renovate changesets
-        uses: ./.github/actions/renovate-changesets
-        with:
-          comment-pr: 'false'
-          token: ${{ steps.get-workflow-access-token.outputs.token }}
+        env:
+          SKIP_COMMIT: 'true'
+        run: pnpx @scaleway/changesets-renovate
 
       - name: Commit and push changesets
-        if: steps.renovate-changesets.outputs.changesets-created > 0
+        if: success()
         run: |
           short_sha=$(git rev-parse --short HEAD)
           git add .


### PR DESCRIPTION
The internal action produces too many errors that must be resolved manually.

## Description

<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Repository configuration

## Changes Made

<!-- List the changes you've made -->

-

## Testing

<!-- Describe the tests you've done -->

- [ ] I have tested these changes locally
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a changeset describing the changes (if applicable)

## Additional Context

<!-- Add any other context about the pull request here -->
