### PR TITLE
chore: update squash merge commit message setting

### DIFF
--- a/common-settings.yaml
+++ b/common-settings.yaml
@@ -97,7 +97,7 @@ repository:
   #  - COMMIT_MESSAGES - default to the branch's commit messages.
   #  - BLANK - default to a blank commit message.
   # Can be one of: PR_BODY, COMMIT_MESSAGES, BLANK
-  squash_merge_commit_message: BLANK
+  squash_merge_commit_message: PR_BODY
 
   # The default value for a merge commit title.
   #  - PR_TITLE - default to the pull request's title.


### PR DESCRIPTION
- Changed the default squash merge commit message from BLANK to PR_BODY.