### PR TITLE
chore(settings): update squash merge commit title and message defaults

### DIFF
--- a/common-settings.yaml
+++ b/common-settings.yaml
@@ -90,14 +90,14 @@ repository:
   #  - PR_TITLE - default to the pull request's title.
   #  - COMMIT_OR_PR_TITLE - default to the commit's title (if only one commit) or the pull request's title (when more than one commit).
   # Can be one of: PR_TITLE, COMMIT_OR_PR_TITLE
-  squash_merge_commit_title: PR_TITLE
+  squash_merge_commit_title: COMMIT_OR_PR_TITLE
 
   # The default value for a squash merge commit message:
   #  - PR_BODY - default to the pull request's body.
   #  - COMMIT_MESSAGES - default to the branch's commit messages.
   #  - BLANK - default to a blank commit message.
   # Can be one of: PR_BODY, COMMIT_MESSAGES, BLANK
-  squash_merge_commit_message: PR_BODY
+  squash_merge_commit_message: COMMIT_MESSAGES
 
   # The default value for a merge commit title.
   #  - PR_TITLE - default to the pull request's title.


### PR DESCRIPTION
- Changed default squash merge commit title from PR_TITLE to COMMIT_OR_PR_TITLE
- Changed default squash merge commit message from PR_BODY to COMMIT_MESSAGES