### PR TITLE
chore: update GitHub App token secrets in copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -195,8 +195,8 @@ All automated workflows use the `bfra-me[bot]` GitHub App with scoped tokens:
 - name: Generate Token
   uses: actions/create-github-app-token@v1
   with:
-    app-id: ${{ secrets.BFRA_ME_BOT_APP_ID }}
-    private-key: ${{ secrets.BFRA_ME_BOT_PRIVATE_KEY }}
+    app-id: ${{ secrets.APPLICATION_ID }}
+    private-key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
 ```
 
 This pattern provides:


### PR DESCRIPTION
- Replace old secret names with more generic APPLICATION_ID and APPLICATION_PRIVATE_KEY