### PR TITLE
chore: update concurrency setting to not cancel in-progress jobs

### DIFF
--- a/.changeset/many-toys-lay.md
+++ b/.changeset/many-toys-lay.md
@@ -1,0 +1,6 @@
+---
+"@bfra.me/.github": minor
+---
+
+Change `concurrency` to not cancel in-progress jobs with the same name.
+  

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -54,7 +54,7 @@ on:
 
 concurrency:
   group: ${{ github.repository }}-${{ github.workflow }}-${{ github.run_number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: read


### PR DESCRIPTION
- Change `cancel-in-progress` to false in the Renovate workflow