### PR TITLE
feat: enhance changeset summary generation for multiple package managers

### DIFF
--- a/.ai/plan/feature-enhanced-renovate-changesets-action-1.md
+++ b/.ai/plan/feature-enhanced-renovate-changesets-action-1.md
@@ -133,7 +133,7 @@ All core parsing engine tasks have been successfully implemented:
 | TASK-022 | Create context-aware changeset summaries based on update type | ✅ | 2025-01-07 |
 | TASK-023 | Implement proper semver bump type determination | ✅ | 2025-01-16 |
 | TASK-024 | Handle multi-package updates and dependency relationships | ✅ | 2025-09-06 |
-| TASK-025 | Generate appropriate changeset content for different manager types | |  |
+| TASK-025 | Generate appropriate changeset content for different manager types | ✅ | 2025-09-05 |
 | TASK-026 | Implement changeset deduplication for grouped updates | |  |
 | TASK-027 | Add support for custom changeset templates and formatting | |  |
 

--- a/.github/actions/renovate-changesets/src/changeset-summary-generator.ts
+++ b/.github/actions/renovate-changesets/src/changeset-summary-generator.ts
@@ -199,6 +199,78 @@ export class ChangesetSummaryGenerator {
           dependencies,
         )
 
+      case 'nuget':
+        return this.generateNuGetSummary(
+          prContext,
+          impactAssessment,
+          categorizationResult,
+          dependencies,
+        )
+
+      case 'composer':
+        return this.generateComposerSummary(
+          prContext,
+          impactAssessment,
+          categorizationResult,
+          dependencies,
+        )
+
+      case 'cargo':
+        return this.generateCargoSummary(
+          prContext,
+          impactAssessment,
+          categorizationResult,
+          dependencies,
+        )
+
+      case 'helm':
+        return this.generateHelmSummary(
+          prContext,
+          impactAssessment,
+          categorizationResult,
+          dependencies,
+        )
+
+      case 'terraform':
+        return this.generateTerraformSummary(
+          prContext,
+          impactAssessment,
+          categorizationResult,
+          dependencies,
+        )
+
+      case 'ansible':
+        return this.generateAnsibleSummary(
+          prContext,
+          impactAssessment,
+          categorizationResult,
+          dependencies,
+        )
+
+      case 'pre-commit':
+        return this.generatePreCommitSummary(
+          prContext,
+          impactAssessment,
+          categorizationResult,
+          dependencies,
+        )
+
+      case 'gitlabci':
+        return this.generateGitLabCISummary(
+          prContext,
+          impactAssessment,
+          categorizationResult,
+          dependencies,
+        )
+
+      case 'circleci':
+        return this.generateCircleCISummary(
+          prContext,
+          impactAssessment,
+          categorizationResult,
+          dependencies,
+        )
+
       case 'lockfile':
         return this.generateLockfileSummary(
           prContext,
@@ -722,6 +794,420 @@ export class ChangesetSummaryGenerator {
   }
 
   /**
+   * Generate NuGet (.NET) specific changeset summary
+   */
+  private generateNuGetSummary(
+    prContext: RenovatePRContext,
+    impactAssessment: ImpactAssessment,
+    _categorizationResult: CategorizationResult,
+    dependencies: string[],
+  ): string {
+    const emoji = this.getEmojiForUpdate(prContext, impactAssessment)
+    const sortedDeps = this.config.sortDependencies ? [...dependencies].sort() : dependencies
+
+    if (prContext.isSecurityUpdate) {
+      return this.generateSecurityUpdateSummary(
+        'NuGet',
+        sortedDeps,
+        prContext,
+        impactAssessment,
+        emoji,
+      )
+    }
+
+    if (sortedDeps.length === 1) {
+      const dependency = sortedDeps[0]
+      if (dependency) {
+        return this.generateSingleDependencySummary(
+          'NuGet',
+          dependency,
+          prContext,
+          impactAssessment,
+          emoji,
+        )
+      }
+    }
+
+    if (sortedDeps.length <= this.config.maxDependenciesToList) {
+      const depList = sortedDeps.map(dep => `\`${dep}\``).join(', ')
+      const summary = `${emoji}Update .NET packages: ${depList}`
+
+      return this.addBreakingChangeWarning(summary, impactAssessment)
+    }
+
+    const summary = `${emoji}Update ${sortedDeps.length} .NET packages`
+    return this.addBreakingChangeWarning(summary, impactAssessment)
+  }
+
+  /**
+   * Generate Composer (PHP) specific changeset summary
+   */
+  private generateComposerSummary(
+    prContext: RenovatePRContext,
+    impactAssessment: ImpactAssessment,
+    _categorizationResult: CategorizationResult,
+    dependencies: string[],
+  ): string {
+    const emoji = this.getEmojiForUpdate(prContext, impactAssessment)
+    const sortedDeps = this.config.sortDependencies ? [...dependencies].sort() : dependencies
+
+    if (prContext.isSecurityUpdate) {
+      return this.generateSecurityUpdateSummary(
+        'Composer',
+        sortedDeps,
+        prContext,
+        impactAssessment,
+        emoji,
+      )
+    }
+
+    if (sortedDeps.length === 1) {
+      const dependency = sortedDeps[0]
+      if (dependency) {
+        return this.generateSingleDependencySummary(
+          'Composer',
+          dependency,
+          prContext,
+          impactAssessment,
+          emoji,
+        )
+      }
+    }
+
+    if (sortedDeps.length <= this.config.maxDependenciesToList) {
+      const depList = sortedDeps.map(dep => `\`${dep}\``).join(', ')
+      const summary = `${emoji}Update PHP dependencies: ${depList}`
+
+      return this.addBreakingChangeWarning(summary, impactAssessment)
+    }
+
+    const summary = `${emoji}Update ${sortedDeps.length} PHP dependencies`
+    return this.addBreakingChangeWarning(summary, impactAssessment)
+  }
+
+  /**
+   * Generate Cargo (Rust) specific changeset summary
+   */
+  private generateCargoSummary(
+    prContext: RenovatePRContext,
+    impactAssessment: ImpactAssessment,
+    _categorizationResult: CategorizationResult,
+    dependencies: string[],
+  ): string {
+    const emoji = this.getEmojiForUpdate(prContext, impactAssessment)
+    const sortedDeps = this.config.sortDependencies ? [...dependencies].sort() : dependencies
+
+    if (prContext.isSecurityUpdate) {
+      return this.generateSecurityUpdateSummary(
+        'Cargo',
+        sortedDeps,
+        prContext,
+        impactAssessment,
+        emoji,
+      )
+    }
+
+    if (sortedDeps.length === 1) {
+      const dependency = sortedDeps[0]
+      if (dependency) {
+        return this.generateSingleDependencySummary(
+          'Cargo',
+          dependency,
+          prContext,
+          impactAssessment,
+          emoji,
+        )
+      }
+    }
+
+    if (sortedDeps.length <= this.config.maxDependenciesToList) {
+      const depList = sortedDeps.map(dep => `\`${dep}\``).join(', ')
+      const summary = `${emoji}Update Rust crates: ${depList}`
+
+      return this.addBreakingChangeWarning(summary, impactAssessment)
+    }
+
+    const summary = `${emoji}Update ${sortedDeps.length} Rust crates`
+    return this.addBreakingChangeWarning(summary, impactAssessment)
+  }
+
+  /**
+   * Generate Helm specific changeset summary
+   */
+  private generateHelmSummary(
+    prContext: RenovatePRContext,
+    impactAssessment: ImpactAssessment,
+    _categorizationResult: CategorizationResult,
+    dependencies: string[],
+  ): string {
+    const emoji = this.getEmojiForUpdate(prContext, impactAssessment)
+    const sortedDeps = this.config.sortDependencies ? [...dependencies].sort() : dependencies
+
+    if (prContext.isSecurityUpdate) {
+      return this.generateSecurityUpdateSummary(
+        'Helm',
+        sortedDeps,
+        prContext,
+        impactAssessment,
+        emoji,
+      )
+    }
+
+    if (sortedDeps.length === 1) {
+      const dep = sortedDeps[0]
+      const versionInfo = prContext.dependencies.find(d => d.name === dep)
+      let versionText = ''
+
+      if (
+        this.config.includeVersionDetails &&
+        versionInfo?.currentVersion &&
+        versionInfo?.newVersion
+      ) {
+        versionText = ` from \`${versionInfo.currentVersion}\` to \`${versionInfo.newVersion}\``
+      }
+
+      return `${emoji}Update Helm chart \`${dep}\`${versionText}`
+    }
+
+    if (sortedDeps.length <= this.config.maxDependenciesToList) {
+      const depList = sortedDeps.map(dep => `\`${dep}\``).join(', ')
+      return `${emoji}Update Helm charts: ${depList}`
+    }
+
+    return `${emoji}Update ${sortedDeps.length} Helm charts`
+  }
+
+  /**
+   * Generate Terraform specific changeset summary
+   */
+  private generateTerraformSummary(
+    prContext: RenovatePRContext,
+    impactAssessment: ImpactAssessment,
+    _categorizationResult: CategorizationResult,
+    dependencies: string[],
+  ): string {
+    const emoji = this.getEmojiForUpdate(prContext, impactAssessment)
+    const sortedDeps = this.config.sortDependencies ? [...dependencies].sort() : dependencies
+
+    if (prContext.isSecurityUpdate) {
+      return this.generateSecurityUpdateSummary(
+        'Terraform',
+        sortedDeps,
+        prContext,
+        impactAssessment,
+        emoji,
+      )
+    }
+
+    if (sortedDeps.length === 1) {
+      const dep = sortedDeps[0]
+      const versionInfo = prContext.dependencies.find(d => d.name === dep)
+      let versionText = ''
+
+      if (
+        this.config.includeVersionDetails &&
+        versionInfo?.currentVersion &&
+        versionInfo?.newVersion
+      ) {
+        versionText = ` from \`${versionInfo.currentVersion}\` to \`${versionInfo.newVersion}\``
+      }
+
+      return `${emoji}Update Terraform provider \`${dep}\`${versionText}`
+    }
+
+    if (sortedDeps.length <= this.config.maxDependenciesToList) {
+      const depList = sortedDeps.map(dep => `\`${dep}\``).join(', ')
+      return `${emoji}Update Terraform providers: ${depList}`
+    }
+
+    return `${emoji}Update ${sortedDeps.length} Terraform providers`
+  }
+
+  /**
+   * Generate Ansible specific changeset summary
+   */
+  private generateAnsibleSummary(
+    prContext: RenovatePRContext,
+    impactAssessment: ImpactAssessment,
+    _categorizationResult: CategorizationResult,
+    dependencies: string[],
+  ): string {
+    const emoji = this.getEmojiForUpdate(prContext, impactAssessment)
+    const sortedDeps = this.config.sortDependencies ? [...dependencies].sort() : dependencies
+
+    if (prContext.isSecurityUpdate) {
+      return this.generateSecurityUpdateSummary(
+        'Ansible',
+        sortedDeps,
+        prContext,
+        impactAssessment,
+        emoji,
+      )
+    }
+
+    if (sortedDeps.length === 1) {
+      const dep = sortedDeps[0]
+      const versionInfo = prContext.dependencies.find(d => d.name === dep)
+      let versionText = ''
+
+      if (
+        this.config.includeVersionDetails &&
+        versionInfo?.currentVersion &&
+        versionInfo?.newVersion
+      ) {
+        versionText = ` from \`${versionInfo.currentVersion}\` to \`${versionInfo.newVersion}\``
+      }
+
+      return `${emoji}Update Ansible role \`${dep}\`${versionText}`
+    }
+
+    if (sortedDeps.length <= this.config.maxDependenciesToList) {
+      const depList = sortedDeps.map(dep => `\`${dep}\``).join(', ')
+      return `${emoji}Update Ansible roles: ${depList}`
+    }
+
+    return `${emoji}Update ${sortedDeps.length} Ansible roles`
+  }
+
+  /**
+   * Generate pre-commit hooks specific changeset summary
+   */
+  private generatePreCommitSummary(
+    prContext: RenovatePRContext,
+    impactAssessment: ImpactAssessment,
+    _categorizationResult: CategorizationResult,
+    dependencies: string[],
+  ): string {
+    const emoji = this.getEmojiForUpdate(prContext, impactAssessment)
+    const sortedDeps = this.config.sortDependencies ? [...dependencies].sort() : dependencies
+
+    if (prContext.isSecurityUpdate) {
+      return this.generateSecurityUpdateSummary(
+        'pre-commit',
+        sortedDeps,
+        prContext,
+        impactAssessment,
+        emoji,
+      )
+    }
+
+    if (sortedDeps.length === 1) {
+      const dep = sortedDeps[0]
+      const versionInfo = prContext.dependencies.find(d => d.name === dep)
+      let versionText = ''
+
+      if (
+        this.config.includeVersionDetails &&
+        versionInfo?.currentVersion &&
+        versionInfo?.newVersion
+      ) {
+        versionText = ` from \`${versionInfo.currentVersion}\` to \`${versionInfo.newVersion}\``
+      }
+
+      return `${emoji}Update pre-commit hook \`${dep}\`${versionText}`
+    }
+
+    if (sortedDeps.length <= this.config.maxDependenciesToList) {
+      const depList = sortedDeps.map(dep => `\`${dep}\``).join(', ')
+      return `${emoji}Update pre-commit hooks: ${depList}`
+    }
+
+    return `${emoji}Update ${sortedDeps.length} pre-commit hooks`
+  }
+
+  /**
+   * Generate GitLab CI specific changeset summary
+   */
+  private generateGitLabCISummary(
+    prContext: RenovatePRContext,
+    impactAssessment: ImpactAssessment,
+    _categorizationResult: CategorizationResult,
+    dependencies: string[],
+  ): string {
+    const emoji = this.getEmojiForUpdate(prContext, impactAssessment)
+    const sortedDeps = this.config.sortDependencies ? [...dependencies].sort() : dependencies
+
+    if (prContext.isSecurityUpdate) {
+      return this.generateSecurityUpdateSummary(
+        'GitLab CI',
+        sortedDeps,
+        prContext,
+        impactAssessment,
+        emoji,
+      )
+    }
+
+    if (sortedDeps.length === 1) {
+      const dep = sortedDeps[0]
+      const versionInfo = prContext.dependencies.find(d => d.name === dep)
+      let versionText = ''
+
+      if (
+        this.config.includeVersionDetails &&
+        versionInfo?.currentVersion &&
+        versionInfo?.newVersion
+      ) {
+        versionText = ` from \`${versionInfo.currentVersion}\` to \`${versionInfo.newVersion}\``
+      }
+
+      return `${emoji}Update GitLab CI dependency \`${dep}\`${versionText}`
+    }
+
+    if (sortedDeps.length <= this.config.maxDependenciesToList) {
+      const depList = sortedDeps.map(dep => `\`${dep}\``).join(', ')
+      return `${emoji}Update GitLab CI dependencies: ${depList}`
+    }
+
+    return `${emoji}Update ${sortedDeps.length} GitLab CI dependencies`
+  }
+
+  /**
+   * Generate CircleCI specific changeset summary
+   */
+  private generateCircleCISummary(
+    prContext: RenovatePRContext,
+    impactAssessment: ImpactAssessment,
+    _categorizationResult: CategorizationResult,
+    dependencies: string[],
+  ): string {
+    const emoji = this.getEmojiForUpdate(prContext, impactAssessment)
+    const sortedDeps = this.config.sortDependencies ? [...dependencies].sort() : dependencies
+
+    if (prContext.isSecurityUpdate) {
+      return this.generateSecurityUpdateSummary(
+        'CircleCI',
+        sortedDeps,
+        prContext,
+        impactAssessment,
+        emoji,
+      )
+    }
+
+    if (sortedDeps.length === 1) {
+      const dep = sortedDeps[0]
+      const versionInfo = prContext.dependencies.find(d => d.name === dep)
+      let versionText = ''
+
+      if (
+        this.config.includeVersionDetails &&
+        versionInfo?.currentVersion &&
+        versionInfo?.newVersion
+      ) {
+        versionText = ` from \`${versionInfo.currentVersion}\` to \`${versionInfo.newVersion}\``
+      }
+
+      return `${emoji}Update CircleCI orb \`${dep}\`${versionText}`
+    }
+
+    if (sortedDeps.length <= this.config.maxDependenciesToList) {
+      const depList = sortedDeps.map(dep => `\`${dep}\``).join(', ')
+      return `${emoji}Update CircleCI orbs: ${depList}`
+    }
+
+    return `${emoji}Update ${sortedDeps.length} CircleCI orbs`
+  }
+
+  /**
    * Get appropriate emoji for update type
    */
   private getEmojiForUpdate(
@@ -763,6 +1249,24 @@ export class ChangesetSummaryGenerator {
         return '☕ '
       case 'go':
         return '🐹 '
+      case 'nuget':
+        return '💎 '
+      case 'composer':
+        return '🐘 '
+      case 'cargo':
+        return '🦀 '
+      case 'helm':
+        return '⎈ '
+      case 'terraform':
+        return '🏗️ '
+      case 'ansible':
+        return '🤖 '
+      case 'pre-commit':
+        return '🪝 '
+      case 'gitlabci':
+        return '🦊 '
+      case 'circleci':
+        return '🔄 '
       default:
         return '📋 '
     }

--- a/.github/actions/renovate-changesets/test/changeset-summary-generator.test.ts
+++ b/.github/actions/renovate-changesets/test/changeset-summary-generator.test.ts
@@ -288,6 +288,366 @@ describe('ChangesetSummaryGenerator', () => {
     })
   })
 
+  describe('nuget dependency summaries', () => {
+    beforeEach(() => {
+      mockPRContext.manager = 'nuget'
+    })
+
+    it('should generate NuGet dependency summary', () => {
+      const summary = generator.generateSummary(
+        mockPRContext,
+        mockImpactAssessment,
+        mockCategorizationResult,
+        'nuget',
+        ['Newtonsoft.Json'],
+      )
+
+      expect(summary).toContain('💎')
+      expect(summary).toContain('Update NuGet dependency `Newtonsoft.Json`')
+    })
+
+    it('should handle multiple NuGet packages', () => {
+      const summary = generator.generateSummary(
+        mockPRContext,
+        mockImpactAssessment,
+        mockCategorizationResult,
+        'nuget',
+        ['Microsoft.Extensions.Logging', 'Newtonsoft.Json'],
+      )
+
+      expect(summary).toContain('Update .NET packages')
+      expect(summary).toContain('`Microsoft.Extensions.Logging`, `Newtonsoft.Json`')
+    })
+  })
+
+  describe('composer dependency summaries', () => {
+    beforeEach(() => {
+      mockPRContext.manager = 'composer'
+    })
+
+    it('should generate Composer dependency summary', () => {
+      const summary = generator.generateSummary(
+        mockPRContext,
+        mockImpactAssessment,
+        mockCategorizationResult,
+        'composer',
+        ['symfony/framework-bundle'],
+      )
+
+      expect(summary).toContain('🐘')
+      expect(summary).toContain('Update Composer dependency `symfony/framework-bundle`')
+    })
+
+    it('should handle multiple PHP packages', () => {
+      const summary = generator.generateSummary(
+        mockPRContext,
+        mockImpactAssessment,
+        mockCategorizationResult,
+        'composer',
+        ['laravel/framework', 'guzzlehttp/guzzle'],
+      )
+
+      expect(summary).toContain('Update PHP dependencies')
+      expect(summary).toContain('`guzzlehttp/guzzle`, `laravel/framework`')
+    })
+  })
+
+  describe('cargo dependency summaries', () => {
+    beforeEach(() => {
+      mockPRContext.manager = 'cargo'
+    })
+
+    it('should generate Cargo dependency summary', () => {
+      const summary = generator.generateSummary(
+        mockPRContext,
+        mockImpactAssessment,
+        mockCategorizationResult,
+        'cargo',
+        ['serde'],
+      )
+
+      expect(summary).toContain('🦀')
+      expect(summary).toContain('Update Cargo dependency `serde`')
+    })
+
+    it('should handle multiple Rust crates', () => {
+      const summary = generator.generateSummary(
+        mockPRContext,
+        mockImpactAssessment,
+        mockCategorizationResult,
+        'cargo',
+        ['tokio', 'serde', 'clap'],
+      )
+
+      expect(summary).toContain('Update Rust crates')
+      expect(summary).toContain('`clap`, `serde`, `tokio`')
+    })
+  })
+
+  describe('helm dependency summaries', () => {
+    beforeEach(() => {
+      mockPRContext.manager = 'helm'
+      mockPRContext.dependencies = [
+        {
+          name: 'nginx-ingress',
+          currentVersion: '1.0.0',
+          newVersion: '2.0.0',
+          manager: 'helm',
+          updateType: 'major',
+          isSecurityUpdate: false,
+          isGrouped: false,
+        },
+      ]
+    })
+
+    it('should generate Helm chart summary with version details', () => {
+      const summary = generator.generateSummary(
+        mockPRContext,
+        mockImpactAssessment,
+        mockCategorizationResult,
+        'helm',
+        ['nginx-ingress'],
+      )
+
+      expect(summary).toContain('⎈')
+      expect(summary).toContain('Update Helm chart `nginx-ingress`')
+      expect(summary).toContain('from `1.0.0` to `2.0.0`')
+    })
+
+    it('should handle multiple Helm charts', () => {
+      const summary = generator.generateSummary(
+        mockPRContext,
+        mockImpactAssessment,
+        mockCategorizationResult,
+        'helm',
+        ['nginx-ingress', 'prometheus', 'grafana'],
+      )
+
+      expect(summary).toContain('Update Helm charts')
+      expect(summary).toContain('`grafana`, `nginx-ingress`, `prometheus`')
+    })
+  })
+
+  describe('terraform dependency summaries', () => {
+    beforeEach(() => {
+      mockPRContext.manager = 'terraform'
+      mockPRContext.dependencies = [
+        {
+          name: 'hashicorp/aws',
+          currentVersion: '4.0.0',
+          newVersion: '5.0.0',
+          manager: 'terraform',
+          updateType: 'major',
+          isSecurityUpdate: false,
+          isGrouped: false,
+        },
+      ]
+    })
+
+    it('should generate Terraform provider summary with version details', () => {
+      const summary = generator.generateSummary(
+        mockPRContext,
+        mockImpactAssessment,
+        mockCategorizationResult,
+        'terraform',
+        ['hashicorp/aws'],
+      )
+
+      expect(summary).toContain('🏗️')
+      expect(summary).toContain('Update Terraform provider `hashicorp/aws`')
+      expect(summary).toContain('from `4.0.0` to `5.0.0`')
+    })
+
+    it('should handle multiple Terraform providers', () => {
+      const summary = generator.generateSummary(
+        mockPRContext,
+        mockImpactAssessment,
+        mockCategorizationResult,
+        'terraform',
+        ['hashicorp/aws', 'hashicorp/azurerm'],
+      )
+
+      expect(summary).toContain('Update Terraform providers')
+      expect(summary).toContain('`hashicorp/aws`, `hashicorp/azurerm`')
+    })
+  })
+
+  describe('ansible dependency summaries', () => {
+    beforeEach(() => {
+      mockPRContext.manager = 'ansible'
+      mockPRContext.dependencies = [
+        {
+          name: 'community.general',
+          currentVersion: '1.0.0',
+          newVersion: '2.0.0',
+          manager: 'ansible',
+          updateType: 'major',
+          isSecurityUpdate: false,
+          isGrouped: false,
+        },
+      ]
+    })
+
+    it('should generate Ansible role summary with version details', () => {
+      const summary = generator.generateSummary(
+        mockPRContext,
+        mockImpactAssessment,
+        mockCategorizationResult,
+        'ansible',
+        ['community.general'],
+      )
+
+      expect(summary).toContain('🤖')
+      expect(summary).toContain('Update Ansible role `community.general`')
+      expect(summary).toContain('from `1.0.0` to `2.0.0`')
+    })
+
+    it('should handle multiple Ansible roles', () => {
+      const summary = generator.generateSummary(
+        mockPRContext,
+        mockImpactAssessment,
+        mockCategorizationResult,
+        'ansible',
+        ['community.general', 'ansible.posix'],
+      )
+
+      expect(summary).toContain('Update Ansible roles')
+      expect(summary).toContain('`ansible.posix`, `community.general`')
+    })
+  })
+
+  describe('pre-commit dependency summaries', () => {
+    beforeEach(() => {
+      mockPRContext.manager = 'pre-commit'
+      mockPRContext.dependencies = [
+        {
+          name: 'pre-commit/pre-commit-hooks',
+          currentVersion: 'v4.0.0',
+          newVersion: 'v4.1.0',
+          manager: 'pre-commit',
+          updateType: 'minor',
+          isSecurityUpdate: false,
+          isGrouped: false,
+        },
+      ]
+    })
+
+    it('should generate pre-commit hook summary with version details', () => {
+      const summary = generator.generateSummary(
+        mockPRContext,
+        mockImpactAssessment,
+        mockCategorizationResult,
+        'pre-commit',
+        ['pre-commit/pre-commit-hooks'],
+      )
+
+      expect(summary).toContain('🪝')
+      expect(summary).toContain('Update pre-commit hook `pre-commit/pre-commit-hooks`')
+      expect(summary).toContain('from `v4.0.0` to `v4.1.0`')
+    })
+
+    it('should handle multiple pre-commit hooks', () => {
+      const summary = generator.generateSummary(
+        mockPRContext,
+        mockImpactAssessment,
+        mockCategorizationResult,
+        'pre-commit',
+        ['pre-commit/pre-commit-hooks', 'psf/black'],
+      )
+
+      expect(summary).toContain('Update pre-commit hooks')
+      expect(summary).toContain('`pre-commit/pre-commit-hooks`, `psf/black`')
+    })
+  })
+
+  describe('gitlab ci dependency summaries', () => {
+    beforeEach(() => {
+      mockPRContext.manager = 'gitlabci'
+      mockPRContext.dependencies = [
+        {
+          name: 'node',
+          currentVersion: '16-alpine',
+          newVersion: '18-alpine',
+          manager: 'gitlabci',
+          updateType: 'major',
+          isSecurityUpdate: false,
+          isGrouped: false,
+        },
+      ]
+    })
+
+    it('should generate GitLab CI dependency summary with version details', () => {
+      const summary = generator.generateSummary(
+        mockPRContext,
+        mockImpactAssessment,
+        mockCategorizationResult,
+        'gitlabci',
+        ['node'],
+      )
+
+      expect(summary).toContain('🦊')
+      expect(summary).toContain('Update GitLab CI dependency `node`')
+      expect(summary).toContain('from `16-alpine` to `18-alpine`')
+    })
+
+    it('should handle multiple GitLab CI dependencies', () => {
+      const summary = generator.generateSummary(
+        mockPRContext,
+        mockImpactAssessment,
+        mockCategorizationResult,
+        'gitlabci',
+        ['node', 'docker', 'alpine'],
+      )
+
+      expect(summary).toContain('Update GitLab CI dependencies')
+      expect(summary).toContain('`alpine`, `docker`, `node`')
+    })
+  })
+
+  describe('circleci dependency summaries', () => {
+    beforeEach(() => {
+      mockPRContext.manager = 'circleci'
+      mockPRContext.dependencies = [
+        {
+          name: 'circleci/node',
+          currentVersion: '16.0.0',
+          newVersion: '18.0.0',
+          manager: 'circleci',
+          updateType: 'major',
+          isSecurityUpdate: false,
+          isGrouped: false,
+        },
+      ]
+    })
+
+    it('should generate CircleCI orb summary with version details', () => {
+      const summary = generator.generateSummary(
+        mockPRContext,
+        mockImpactAssessment,
+        mockCategorizationResult,
+        'circleci',
+        ['circleci/node'],
+      )
+
+      expect(summary).toContain('🔄')
+      expect(summary).toContain('Update CircleCI orb `circleci/node`')
+      expect(summary).toContain('from `16.0.0` to `18.0.0`')
+    })
+
+    it('should handle multiple CircleCI orbs', () => {
+      const summary = generator.generateSummary(
+        mockPRContext,
+        mockImpactAssessment,
+        mockCategorizationResult,
+        'circleci',
+        ['circleci/node', 'circleci/aws-cli'],
+      )
+
+      expect(summary).toContain('Update CircleCI orbs')
+      expect(summary).toContain('`circleci/aws-cli`, `circleci/node`')
+    })
+  })
+
   describe('custom template handling', () => {
     it('should use custom template when provided', () => {
       const template = 'Custom: {updateType} {dependencies} {version}'


### PR DESCRIPTION
- Add support for generating summaries for NuGet, Composer, Cargo, Helm, Terraform, Ansible, pre-commit, GitLab CI, and CircleCI.
- Implement tests for each new summary type to ensure correctness.
- Update existing summary generation logic to accommodate new package managers.

Relates to TASK-025 on #1097.