### PR TITLE
feat: implement automatic commit and push for Renovate branches

### DIFF
--- a/.ai/plan/feature-enhanced-renovate-changesets-action-1.md
+++ b/.ai/plan/feature-enhanced-renovate-changesets-action-1.md
@@ -145,7 +145,7 @@ All core parsing engine tasks have been successfully implemented:
 |------|-------------|-----------|------|
 | TASK-028 | Implement Git operations for committing changeset files | ✅ | 2025-09-07 |
 | TASK-029 | Handle GitHub App authentication for Git operations | ✅ | 2025-09-07 |
-| TASK-030 | Commit changesets back to Renovate branches automatically | |  |
+| TASK-030 | Commit changesets back to Renovate branches automatically | ✅ | 2025-09-07 |
 | TASK-031 | Update PR descriptions with changeset information | |  |
 | TASK-032 | Handle merge conflicts and branch updates gracefully | |  |
 | TASK-033 | Implement PR comment updates with changeset details | |  |

--- a/.github/actions/renovate-changesets/action.yaml
+++ b/.github/actions/renovate-changesets/action.yaml
@@ -101,6 +101,11 @@ outputs:
     description: List of committed changeset files (JSON array)
   git-error:
     description: Error message if git operations failed
+  # TASK-030: Push operations outputs
+  push-success:
+    description: Whether changeset files were successfully pushed to the remote branch
+  push-error:
+    description: Error message if push operations failed
 
 runs:
   using: node20

--- a/.github/actions/renovate-changesets/src/index.ts
+++ b/.github/actions/renovate-changesets/src/index.ts
@@ -1315,9 +1315,9 @@ async function run(): Promise<void> {
     core.setOutput('average-risk-level', categorizationResult.summary.averageRiskLevel.toString())
     core.setOutput('categorization-confidence', categorizationResult.confidence)
 
-    // TASK-028/029: Commit changeset files back to Renovate branch if enabled
+    // TASK-028/029/030: Commit changeset files back to Renovate branch if enabled
     try {
-      const gitOps = createGitOperations(workingDirectory)
+      const gitOps = createGitOperations(workingDirectory, owner, repo, branchName)
       const commitResult = await gitOps.commitChangesetFiles()
 
       // Set git operation outputs
@@ -1325,6 +1325,9 @@ async function run(): Promise<void> {
       core.setOutput('commit-sha', commitResult.commitSha || '')
       core.setOutput('committed-files', JSON.stringify(commitResult.committedFiles))
       core.setOutput('git-error', commitResult.error || '')
+      // TASK-030: Add push operation outputs
+      core.setOutput('push-success', (commitResult.pushSuccess || false).toString())
+      core.setOutput('push-error', commitResult.pushError || '')
 
       if (commitResult.success && commitResult.committedFiles.length > 0) {
         core.info(
@@ -1342,6 +1345,9 @@ async function run(): Promise<void> {
       core.setOutput('commit-sha', '')
       core.setOutput('committed-files', JSON.stringify([]))
       core.setOutput('git-error', gitErrorMessage)
+      // TASK-030: Add push operation error outputs
+      core.setOutput('push-success', 'false')
+      core.setOutput('push-error', '')
     }
 
     // Create PR comment with changeset details if enabled
@@ -1390,11 +1396,13 @@ async function run(): Promise<void> {
     core.setOutput('average-risk-level', '0')
     core.setOutput('categorization-confidence', 'low')
 
-    // TASK-028/029: Set git operations error outputs
+    // TASK-028/029/030: Set git operations error outputs
     core.setOutput('commit-success', 'false')
     core.setOutput('commit-sha', '')
     core.setOutput('committed-files', JSON.stringify([]))
     core.setOutput('git-error', '')
+    core.setOutput('push-success', 'false')
+    core.setOutput('push-error', '')
 
     core.setFailed(`Action failed: ${errorMessage}`)
   }


### PR DESCRIPTION
- Add functionality to commit changeset files back to Renovate branches
- Implement push operations to remote branches with success/error outputs
- Update GitOperations interface to include repository and branch details
- Modify action outputs to reflect push operation results

Relates to TASK-030 on #1098.