### PR TITLE
chore: add changeset for upgrading renovate-action to v8

### DIFF
--- a/.changeset/slow-trams-play.md
+++ b/.changeset/slow-trams-play.md
@@ -1,0 +1,6 @@
+---
+"@bfra.me/.github": minor
+---
+
+Upgrade `bfra-me/renovate-action` to v8 (#1332).
+  


### PR DESCRIPTION
- Create a new changeset file for the upgrade
- Document the upgrade of `bfra-me/renovate-action` to v8