### PR TITLE
fix(workflows): checkout repo for all event types in update-repo-settings

### DIFF
--- a/.github/workflows/update-repo-settings.yaml
+++ b/.github/workflows/update-repo-settings.yaml
@@ -27,8 +27,7 @@ jobs:
     name: Update Repository Settings
     runs-on: ubuntu-latest
     steps:
-      - if: github.event_name == 'push'
-        name: Checkout Repository
+      - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - id: filter


### PR DESCRIPTION
## Summary

Fixes the scheduled/dispatch/call runs of the `update-repo-settings` workflow failing with `Can't find 'action.yml'`.

- The `actions/checkout` step was conditional on `github.event_name == 'push'`, but the local action (`./.github/actions/update-repository-settings`) needs the repo checked out for all event types
- Previously `elstudio/actions-settings@v3-beta` was a remote action that didn't need checkout — the local replacement does
- The `paths-filter` step remains push-only (used to skip when no relevant files changed on push)

Fixes: https://github.com/bfra-me/.github/actions/runs/22986595479/job/66738171508