### PR TITLE
fix(ci): pin self actions with Renovate rules

### DIFF
--- a/.changeset/yellow-lies-spend.md
+++ b/.changeset/yellow-lies-spend.md
@@ -1,0 +1,6 @@
+---
+"@bfra.me/.github": patch
+---
+
+Avoid recursive self-action update PRs.
+  

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -21,6 +21,18 @@
       matchManagers: ['mise'],
       enabled: false,
     },
+    {
+      description: 'Use released versions of renovate-changesets action; disable digest pinning to prevent recursive updates.',
+      matchPackageNames: ['bfra-me/.github/.github/actions/renovate-changesets'],
+      extractVersion: '^renovate-changesets@(?<version>.+)$',
+      pinDigests: false,
+    },
+    {
+      description: 'Use released versions of update-repository-settings action; disable digest pinning to prevent recursive updates.',
+      matchPackageNames: ['bfra-me/.github/.github/actions/update-repository-settings'],
+      extractVersion: '^update-repository-settings@(?<version>.+)$',
+      pinDigests: false,
+    },
   ],
   postUpgradeTasks: {
     commands: ['pnpm run bootstrap', 'pnpm run build', 'pnpm run fix'],

--- a/.github/workflows/renovate-changeset.yaml
+++ b/.github/workflows/renovate-changeset.yaml
@@ -48,7 +48,7 @@ jobs:
 
       - id: renovate-changesets
         name: 🖌️ Generate Renovate changesets
-        uses: ./.github/actions/renovate-changesets
+        uses: bfra-me/.github/.github/actions/renovate-changesets@d6bbf902dc6392e6017529ba849d93684a3b3fee # renovate-changesets@0.2.15
         with:
           token: ${{ steps.get-workflow-access-token.outputs.token }}
           commit-back: 'true'

--- a/.github/workflows/update-repo-settings.yaml
+++ b/.github/workflows/update-repo-settings.yaml
@@ -53,6 +53,6 @@ jobs:
           GITHUB_TOKEN: ${{ steps.get-workflow-access-token.outputs.token }}
         if: github.event_name != 'push' || steps.filter.outputs.changes == 'true'
         name: Update Repository Settings (${{ github.repository }})
-        uses: ./.github/actions/update-repository-settings
+        uses: bfra-me/.github/.github/actions/update-repository-settings@d6bbf902dc6392e6017529ba849d93684a3b3fee # update-repository-settings@0.1.1
         with:
           token: ${{ steps.get-workflow-access-token.outputs.token }}


### PR DESCRIPTION
Restore pinned external references for local reusable actions while preventing recursive self-update pull requests.

- switch `renovate-changeset` workflow to `bfra-me/.github/.github/actions/renovate-changesets@d6bbf90...`
- switch `update-repo-settings` workflow to `bfra-me/.github/.github/actions/update-repository-settings@d6bbf90...`
- add Renovate package rules for both self-hosted actions to:
  - extract versions from tags (`renovate-changesets@x.y.z`, `update-repository-settings@x.y.z`)
  - disable digest pinning to avoid update loops on every main push