### PR TITLE
fix(renovate): use correct depName for internal action package rules

### DIFF
--- a/.changeset/fix-renovate-depname-matching.md
+++ b/.changeset/fix-renovate-depname-matching.md
@@ -1,0 +1,5 @@
+---
+"@bfra.me/.github": patch
+---
+
+Fix Renovate `matchDepNames` for internal actions to use the actual `depName` (`bfra-me/.github`) instead of the full subdirectory path. Adds `matchFileNames` to scope `extractVersion` patterns per action, enabling proper release-based version tracking and stopping self-referential digest update PRs.

--- a/.changeset/renovate-de30410.md
+++ b/.changeset/renovate-de30410.md
@@ -2,4 +2,4 @@
 '@bfra.me/.github': patch
 ---
 
-📋 Update unknown dependencies: bfra-me/.github, update
+📦 Update `bfra-me/.github` action digests (renovate-changesets, update-repository-settings)

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -23,13 +23,15 @@
     },
     {
       description: 'Use released versions of renovate-changesets action; disable digest pinning to prevent recursive updates.',
-      matchDepNames: ['bfra-me/.github/.github/actions/renovate-changesets'],
+      matchDepNames: ['bfra-me/.github'],
+      matchFileNames: ['.github/workflows/renovate-changeset.yaml'],
       extractVersion: '^renovate-changesets@(?<version>.+)$',
       pinDigests: false,
     },
     {
       description: 'Use released versions of update-repository-settings action; disable digest pinning to prevent recursive updates.',
-      matchDepNames: ['bfra-me/.github/.github/actions/update-repository-settings'],
+      matchDepNames: ['bfra-me/.github'],
+      matchFileNames: ['.github/workflows/update-repo-settings.yaml'],
       extractVersion: '^update-repository-settings@(?<version>.+)$',
       pinDigests: false,
     },


### PR DESCRIPTION
## Summary

Fixes Renovate `matchDepNames` rules for internal actions (`renovate-changesets`, `update-repository-settings`) to use the actual `depName` that Renovate's github-actions manager assigns.

## Root Cause

Renovate's github-actions manager sets `depName` to the bare repo name (`bfra-me/.github`), **not** the full subdirectory path (`bfra-me/.github/.github/actions/renovate-changesets`). Confirmed via [Renovate debug logs](https://github.com/bfra-me/.github/actions/runs/23058324999/job/66977802662):

```json
{
  "depName": "bfra-me/.github",
  "replaceString": "bfra-me/.github/.github/actions/renovate-changesets@e2c57f3...",
  "packageName": "bfra-me/.github"
}
```

The existing `matchDepNames` rules (introduced in #1721) used the full subdirectory paths — which **never matched**. As a result, `extractVersion` and `pinDigests: false` were never applied, causing:
- Perpetual digest update PRs on every main commit (#1724, #1726)
- No version tracking from release tags like `renovate-changesets@0.2.16`
- Malformed changeset summaries from the changeset action processing these digest PRs

## Changes

- **`.github/renovate.json5`**: Changed `matchDepNames` from full subdirectory paths to `bfra-me/.github`. Added `matchFileNames` to scope each `extractVersion` pattern to the correct workflow file (preventing cross-contamination with reusable workflow refs in `workflow-templates/`).
- **`.changeset/renovate-de30410.md`**: Patched corrupted changeset summary from PR #1724 (`📋 Update unknown dependencies: bfra-me/.github, update` → proper description).
- **`.changeset/fix-renovate-depname-matching.md`**: Changeset for this fix.

## Expected Behavior After Merge

1. Renovate stops creating digest update PRs for internal actions
2. `extractVersion` correctly maps release tags (`renovate-changesets@X.Y.Z`) to semver versions
3. Renovate creates version-based update PRs only when new releases are published
4. Release PR #1725 body no longer contains corrupted changeset entry

Closes the remaining work from #1713.