### PR TITLE
feat: auto-update internal action SHA pins during release

### DIFF
--- a/.changeset/release-auto-pin.md
+++ b/.changeset/release-auto-pin.md
@@ -1,0 +1,8 @@
+---
+'@bfra.me/.github': patch
+---
+
+Auto-update internal action SHA pins during release
+
+- When `renovate-changesets` or `update-repository-settings` is released, automatically update the SHA pin and version comment in the corresponding workflow file
+- Eliminates the Renovate follow-up PR that previously updated the SHA pin, which generated an unnecessary patch changeset and extra release cycle

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -215,7 +215,7 @@ async function main() {
 
   for (const {pkg, tagName} of releasedPackages) {
     const changelogPath = path.join(pkg.dir, 'CHANGELOG.md')
-    let changelog
+    let changelog: string
     try {
       changelog = await fs.readFile(changelogPath, 'utf8')
     } catch (error) {
@@ -256,6 +256,78 @@ async function main() {
     console.log(`Created release for ${tagName} targetting ${releaseSha}`)
 
     await fs.unlink(notesPath)
+  }
+
+  await updateInternalWorkflowPins(releasedPackages, releaseSha.toString(), cwd)
+}
+
+interface WorkflowPinMapping {
+  packageName: string
+  files: {path: string; pattern: RegExp; versionPrefix: string}[]
+}
+
+const WORKFLOW_PIN_MAPPINGS: WorkflowPinMapping[] = [
+  {
+    packageName: 'renovate-changesets',
+    files: [
+      {
+        path: '.github/workflows/renovate-changeset.yaml',
+        pattern:
+          /(uses:\s*bfra-me\/\.github\/\.github\/actions\/renovate-changesets@)[a-f0-9]+(\s+#\s*)[\w.]+/g,
+        versionPrefix: '',
+      },
+    ],
+  },
+  {
+    packageName: 'update-repository-settings',
+    files: [
+      {
+        path: '.github/workflows/update-repo-settings.yaml',
+        pattern:
+          /(uses:\s*bfra-me\/\.github\/\.github\/actions\/update-repository-settings@)[a-f0-9]+(\s+#\s*)[\w.]+/g,
+        versionPrefix: '',
+      },
+    ],
+  },
+]
+
+async function updateInternalWorkflowPins(
+  releasedPackages: {pkg: Package; tagName: string}[],
+  releaseSha: string,
+  cwd: string,
+) {
+  const updatedFiles: string[] = []
+
+  for (const {pkg} of releasedPackages) {
+    const mapping = WORKFLOW_PIN_MAPPINGS.find(m => m.packageName === pkg.packageJson.name)
+    if (!mapping) continue
+
+    const version = `${mapping.files[0]?.versionPrefix ?? ''}${pkg.packageJson.version}`
+    for (const file of mapping.files) {
+      const filePath = path.join(cwd, file.path)
+      try {
+        const content = await fs.readFile(filePath, 'utf8')
+        const updated = content.replace(file.pattern, `$1${releaseSha}$2${version}`)
+        if (updated !== content) {
+          await fs.writeFile(filePath, updated)
+          updatedFiles.push(file.path)
+          console.log(`Updated ${file.path}: pinned to ${releaseSha} (${version})`)
+        }
+      } catch (error) {
+        if (isErrorWithCode(error, 'ENOENT')) {
+          console.log(`Skipping ${file.path}: file not found`)
+          continue
+        }
+        throw error
+      }
+    }
+  }
+
+  if (updatedFiles.length > 0) {
+    await exec('git', ['add', ...updatedFiles], {cwd})
+    await exec('git', ['commit', '-m', 'chore: update internal action SHA pins [skip ci]'], {cwd})
+    await exec('git', ['push'], {cwd})
+    console.log(`Pushed SHA pin updates for: ${updatedFiles.join(', ')}`)
   }
 }
 


### PR DESCRIPTION
## Summary

Eliminates the Renovate round-trip that occurs after every `renovate-changesets` or `update-repository-settings` release:

**Before**: release merges → Renovate detects stale SHA pin → creates PR to update workflow file → generates patch changeset for `@bfra.me/.github` → triggers another release cycle

**After**: release merges → release script updates SHA pins in the same run → single release, no follow-up

## How it works

After the release script creates tags and GitHub releases, it checks if any of the released packages are `renovate-changesets` or `update-repository-settings`. If so, it:

1. Reads the corresponding workflow file (`.github/workflows/renovate-changeset.yaml` or `.github/workflows/update-repo-settings.yaml`)
2. Replaces the SHA pin and version comment with the release commit's SHA and new version
3. Commits with `[skip ci]` and pushes

The `[skip ci]` prevents a redundant CI run since the change is just a SHA pin update with no code changes.

## Mapping

| Package | Workflow file |
|---------|--------------|
| `renovate-changesets` | `.github/workflows/renovate-changeset.yaml` |
| `update-repository-settings` | `.github/workflows/update-repo-settings.yaml` |

## Verification

| Check | Result |
|-------|--------|
| `pnpm run type-check` | ✅ |
| `pnpm run lint` | ✅ |
| 361 tests pass | ✅ |