### PR TITLE
fix: include workflow-templates in release auto-pin updates

### DIFF
--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -289,6 +289,29 @@ const WORKFLOW_PIN_MAPPINGS: WorkflowPinMapping[] = [
       },
     ],
   },
+  {
+    packageName: '@bfra.me/.github',
+    files: [
+      {
+        path: 'workflow-templates/renovate-changesets.yaml',
+        pattern:
+          /(uses:\s*bfra-me\/\.github\/\.github\/workflows\/renovate-changeset\.yaml@)[a-f0-9]+(\s+#\s*)[\w.]+/g,
+        versionPrefix: 'v',
+      },
+      {
+        path: 'workflow-templates/renovate.yaml',
+        pattern:
+          /(uses:\s*bfra-me\/\.github\/\.github\/workflows\/renovate\.yaml@)[a-f0-9]+(\s+#\s*)[\w.]+/g,
+        versionPrefix: 'v',
+      },
+      {
+        path: 'workflow-templates/update-repo-settings.yaml',
+        pattern:
+          /(uses:\s*bfra-me\/\.github\/\.github\/workflows\/update-repo-settings\.yaml@)[a-f0-9]+(\s+#\s*)[\w.]+/g,
+        versionPrefix: 'v',
+      },
+    ],
+  },
 ]
 
 async function updateInternalWorkflowPins(


### PR DESCRIPTION
## Summary

Adds `workflow-templates/` to the release script's auto-pin mappings, closing the recursive release loop seen in PR #1825.

**The cycle**: root package released → Renovate updates `workflow-templates/*.yaml` SHA pins → generates `@bfra.me/.github` patch changeset → triggers another release → repeat.

## Fix

Added `@bfra.me/.github` to `WORKFLOW_PIN_MAPPINGS` with three workflow template files:

| File | Pattern |
|------|---------|
| `workflow-templates/renovate-changesets.yaml` | `renovate-changeset.yaml@SHA # vVERSION` |
| `workflow-templates/renovate.yaml` | `renovate.yaml@SHA # vVERSION` |
| `workflow-templates/update-repo-settings.yaml` | `update-repo-settings.yaml@SHA # vVERSION` |

Uses `versionPrefix: 'v'` since workflow templates use `v4.13.0` format (vs `0.2.26` for actions).

Now when any release runs, the auto-pin PR includes ALL internal references — both the action workflow files AND the workflow templates.