### PR TITLE
fix: replace internal action SHA pins with self-checkout at workflow SHA

### DIFF
--- a/.changeset/self-checkout-actions.md
+++ b/.changeset/self-checkout-actions.md
@@ -1,0 +1,5 @@
+---
+"@bfra.me/.github": minor
+---
+
+Replace hardcoded SHA pins for internal actions in reusable workflows with self-checkout at `github.workflow_sha`. Actions now always match the workflow version — no timing gap, no recursive release cycle, no separate "update internal action SHA pins" automation needed for action packages.

--- a/.github/workflows/renovate-changeset.yaml
+++ b/.github/workflows/renovate-changeset.yaml
@@ -47,9 +47,17 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ steps.get-workflow-access-token.outputs.token }}
 
+      - name: Checkout action (self-checkout at workflow SHA)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: bfra-me/.github
+          ref: ${{ github.workflow_sha }}
+          path: .bfra-me-github
+          sparse-checkout: .github/actions/renovate-changesets
+
       - id: renovate-changesets
         name: 🖌️ Generate Renovate changesets
-        uses: bfra-me/.github/.github/actions/renovate-changesets@da61f98c46e041e72fcce741fd76cd14dedd4459 # 0.2.27
+        uses: ./.bfra-me-github/.github/actions/renovate-changesets
         with:
           token: ${{ steps.get-workflow-access-token.outputs.token }}
           commit-back: 'true'

--- a/.github/workflows/update-repo-settings.yaml
+++ b/.github/workflows/update-repo-settings.yaml
@@ -50,10 +50,19 @@ jobs:
           app-id: ${{ secrets.APPLICATION_ID }}
           private-key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
 
+      - if: github.event_name != 'push' || steps.filter.outputs.changes == 'true'
+        name: Checkout action (self-checkout at workflow SHA)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: bfra-me/.github
+          ref: ${{ github.workflow_sha }}
+          path: .bfra-me-github
+          sparse-checkout: .github/actions/update-repository-settings
+
       - env:
           GITHUB_TOKEN: ${{ steps.get-workflow-access-token.outputs.token }}
         if: github.event_name != 'push' || steps.filter.outputs.changes == 'true'
         name: Update Repository Settings (${{ github.repository }})
-        uses: bfra-me/.github/.github/actions/update-repository-settings@7cdb7496c5b9c7c7fdf706e3cc0bf8163ca61927 # 0.1.5
+        uses: ./.bfra-me-github/.github/actions/update-repository-settings
         with:
           token: ${{ steps.get-workflow-access-token.outputs.token }}

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -268,28 +268,6 @@ interface WorkflowPinMapping {
 
 const WORKFLOW_PIN_MAPPINGS: WorkflowPinMapping[] = [
   {
-    packageName: 'renovate-changesets',
-    files: [
-      {
-        path: '.github/workflows/renovate-changeset.yaml',
-        pattern:
-          /(uses:\s*bfra-me\/\.github\/\.github\/actions\/renovate-changesets@)[a-f0-9]+(\s+#\s*)[\w.]+/g,
-        versionPrefix: '',
-      },
-    ],
-  },
-  {
-    packageName: 'update-repository-settings',
-    files: [
-      {
-        path: '.github/workflows/update-repo-settings.yaml',
-        pattern:
-          /(uses:\s*bfra-me\/\.github\/\.github\/actions\/update-repository-settings@)[a-f0-9]+(\s+#\s*)[\w.]+/g,
-        versionPrefix: '',
-      },
-    ],
-  },
-  {
     packageName: '@bfra.me/.github',
     files: [
       {


### PR DESCRIPTION
## Summary

Eliminates the timing gap where consumers of reusable workflows got stale action code after a release, and the recursive release cycle triggered by SHA pin updates.

## Problem

When an action package (e.g. `update-repository-settings`) was released:

1. Release commit includes new action code in `dist/`
2. But the reusable workflow in the **same commit** still has the **old** SHA pin
3. A separate "update internal action SHA pins" commit updates the pin **after** the release
4. Consumers referencing the release commit get the **old** action code
5. Updating the pin would require a changeset for `@bfra.me/.github` → recursive release

## Solution

Replace hardcoded SHA pins with a self-checkout pattern using `github.workflow_sha`:

```yaml
# BEFORE — stale pin, timing gap
uses: bfra-me/.github/.github/actions/update-repository-settings@{old-SHA} # 0.1.5

# AFTER — always matches the workflow version
- uses: actions/checkout@...
  with:
    repository: bfra-me/.github
    ref: ${{ github.workflow_sha }}
    path: .bfra-me-github
    sparse-checkout: .github/actions/update-repository-settings
- uses: ./.bfra-me-github/.github/actions/update-repository-settings
```

`github.workflow_sha` resolves to the commit of the reusable workflow being executed — so the action code always matches the workflow version, across all trigger types (`workflow_call`, `push`, `schedule`, `workflow_dispatch`).

## Changes

- **`.github/workflows/update-repo-settings.yaml`** — self-checkout for `update-repository-settings`
- **`.github/workflows/renovate-changeset.yaml`** — self-checkout for `renovate-changesets`
- **`scripts/release.ts`** — removed `renovate-changesets` and `update-repository-settings` from `WORKFLOW_PIN_MAPPINGS` (only root `@bfra.me/.github` workflow-template pins remain)

## Verification

- `pnpm run type-check` — pass
- `pnpm run lint` — pass
- `pnpm build` — pass
- `pnpm test` — **496 tests pass**