### PR TITLE
chore: update all actions to Node.js 24 runtime

### DIFF
--- a/.changeset/node24-actions.md
+++ b/.changeset/node24-actions.md
@@ -1,0 +1,7 @@
+---
+"renovate-changesets": patch
+"update-metadata": patch
+"update-repository-settings": patch
+---
+
+Update action runtime from Node.js 20 to Node.js 24.

--- a/.github/actions/renovate-changesets/action.yaml
+++ b/.github/actions/renovate-changesets/action.yaml
@@ -175,5 +175,5 @@ outputs:
     description: Detailed results for each PR operation (JSON array)
 
 runs:
-  using: node20
+  using: node24
   main: dist/index.js

--- a/.github/actions/update-metadata/action.yaml
+++ b/.github/actions/update-metadata/action.yaml
@@ -8,5 +8,5 @@ inputs:
     description: GitHub token with repo write access.
     required: true
 runs:
-  using: node20
+  using: node24
   main: dist/index.js

--- a/.github/actions/update-repository-settings/action.yml
+++ b/.github/actions/update-repository-settings/action.yml
@@ -11,5 +11,5 @@ inputs:
     description: Path to the settings file.
     default: .github/settings.yml
 runs:
-  using: node20
+  using: node24
   main: dist/index.js


### PR DESCRIPTION
## Summary

Updates all three actions from `node20` to `node24` runtime, addressing the GitHub Actions deprecation warning:

> Node.js 20 actions are deprecated. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.

## Changes

- `.github/actions/renovate-changesets/action.yaml` — `using: node20` → `using: node24`
- `.github/actions/update-metadata/action.yaml` — `using: node20` → `using: node24`
- `.github/actions/update-repository-settings/action.yml` — `using: node20` → `using: node24`

## Verification

- `pnpm run type-check` — pass
- `pnpm run lint` — pass
- `pnpm build` — pass
- `pnpm test` — 496 tests pass