### PR TITLE
fix: use GITHUB_WORKFLOW_REF to resolve self-checkout ref

### DIFF
--- a/.changeset/workflow-ref-fix.md
+++ b/.changeset/workflow-ref-fix.md
@@ -1,0 +1,5 @@
+---
+"@bfra.me/.github": patch
+---
+
+Fix self-checkout in reusable workflows: use `GITHUB_WORKFLOW_REF` to resolve the correct ref instead of `github.workflow_sha`, which resolves to the caller's SHA during `workflow_call`.

--- a/.github/workflows/renovate-changeset.yaml
+++ b/.github/workflows/renovate-changeset.yaml
@@ -47,11 +47,15 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ steps.get-workflow-access-token.outputs.token }}
 
-      - name: Checkout action (self-checkout at workflow SHA)
+      - id: workflow-ref
+        name: Resolve workflow ref
+        run: echo "ref=${GITHUB_WORKFLOW_REF##*@}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout action
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: bfra-me/.github
-          ref: ${{ github.workflow_sha }}
+          ref: ${{ steps.workflow-ref.outputs.ref }}
           token: ${{ steps.get-workflow-access-token.outputs.token }}
           path: .bfra-me-github
           sparse-checkout: .github/actions/renovate-changesets

--- a/.github/workflows/update-repo-settings.yaml
+++ b/.github/workflows/update-repo-settings.yaml
@@ -50,12 +50,17 @@ jobs:
           app-id: ${{ secrets.APPLICATION_ID }}
           private-key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
 
+      - id: workflow-ref
+        if: github.event_name != 'push' || steps.filter.outputs.changes == 'true'
+        name: Resolve workflow ref
+        run: echo "ref=${GITHUB_WORKFLOW_REF##*@}" >> "$GITHUB_OUTPUT"
+
       - if: github.event_name != 'push' || steps.filter.outputs.changes == 'true'
-        name: Checkout action (self-checkout at workflow SHA)
+        name: Checkout action
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: bfra-me/.github
-          ref: ${{ github.workflow_sha }}
+          ref: ${{ steps.workflow-ref.outputs.ref }}
           token: ${{ steps.get-workflow-access-token.outputs.token }}
           path: .bfra-me-github
           sparse-checkout: .github/actions/update-repository-settings


### PR DESCRIPTION
## Summary

Fixes the self-checkout still failing after the token fix (#1893) — `github.workflow_sha` resolves to the **caller's** commit SHA during `workflow_call`, not the reusable workflow's.

Failed run: https://github.com/marcusrbrown/copiloting/actions/runs/23554253439/job/68576507228

## Root Cause

```
fatal: remote error: upload-pack: not our ref ad579389f49fa68613cb9c64b48d53c8305fb615
```

`ad579389` is a commit in `marcusrbrown/copiloting`, not `bfra-me/.github`. Despite the GitHub docs suggesting `github.workflow_sha` refers to the reusable workflow, empirical testing confirms it resolves to the **caller's** workflow SHA during `workflow_call`. Fro Bot's [earlier warning](#issuecomment-4124877238) was correct.

## Fix

Extract the ref from `GITHUB_WORKFLOW_REF` environment variable instead:

```yaml
- id: workflow-ref
  run: echo "ref=${GITHUB_WORKFLOW_REF##*@}" >> "$GITHUB_OUTPUT"

- uses: actions/checkout@...
  with:
    repository: bfra-me/.github
    ref: ${{ steps.workflow-ref.outputs.ref }}
```

`GITHUB_WORKFLOW_REF` format: `bfra-me/.github/.github/workflows/update-repo-settings.yaml@refs/heads/main` (or `@<sha>`). The `${var##*@}` extracts the ref after `@`, which correctly identifies the reusable workflow's ref in all trigger contexts.

## Changes

- `.github/workflows/update-repo-settings.yaml` — resolve ref from `GITHUB_WORKFLOW_REF`
- `.github/workflows/renovate-changeset.yaml` — same