### PR TITLE
doc: refresh AGENTS.md and add update-repository-settings AGENTS.md

### DIFF
--- a/.github/actions/update-repository-settings/AGENTS.md
+++ b/.github/actions/update-repository-settings/AGENTS.md
@@ -1,0 +1,67 @@
+# update-repository-settings Action
+
+Applies repository settings from YAML config (typically `.github/settings.yml` with optional `_extends` for remote inheritance). Plugin-based architecture — each GitHub resource type is a separate plugin.
+
+## STRUCTURE
+
+```
+src/
+├── index.ts              # Entry point — delegates to run()
+├── config.ts             # Config loading: YAML parse, remote extends, base64 decode, deepMerge
+├── diff.ts               # deepMerge + diffCollections (detect add/update/remove)
+├── normalize.ts          # Normalize comma-delimited strings and hex colors
+├── plugins/
+│   ├── index.ts          # Plugin registry + applySettings() orchestrator
+│   ├── branches.ts       # Branch protection: status checks, reviews, restrictions
+│   ├── collaborators.ts  # Collaborator permissions (admin/push/pull)
+│   ├── environments.ts   # Deployment environments + protection rules
+│   ├── labels.ts         # Issue/PR labels (color, description)
+│   ├── milestones.ts     # Milestones (state, due date, description)
+│   ├── repository.ts     # Core repo settings (description, topics, visibility, features)
+│   ├── rulesets.ts       # Branch/tag rulesets
+│   └── teams.ts          # Team permissions
+├── __tests__/            # Unit tests for config, diff, normalize, index
+└── plugins/__tests__/    # Per-plugin test suites (branches, collaborators, etc.)
+```
+
+## WHERE TO LOOK
+
+| Task | Location | Notes |
+| --- | --- | --- |
+| Add new resource type | `src/plugins/` | Create plugin fn, register in `PLUGIN_REGISTRY` |
+| Fix branch protection | `src/plugins/branches.ts` | `cleanupMergedProtection` handles org vs user repos |
+| Fix status check sync | `src/plugins/branches.ts` | `resolveStatusCheckConflict()` resolves checks/contexts |
+| Change config loading | `src/config.ts` | `loadConfig()` supports `_extends` + remote configs |
+| Fix collection diffing | `src/diff.ts` | `diffCollections()` returns add/update/remove sets |
+| Add/modify plugin tests | `src/plugins/__tests__/` | Each plugin has own test file |
+| Change repo settings fields | `src/plugins/repository.ts` | Topics and security toggles use separate API endpoints |
+
+## CONVENTIONS
+
+- **Plugin pattern** — each resource type exports a `Plugin` function: `(octokit, owner, repo, config) => Promise<void>`
+- `PLUGIN_REGISTRY` maps config keys to plugin functions
+- `applySettings()` iterates config keys, skips unknown keys, aggregates errors
+- Config supports `_extends` for remote YAML inheritance via `loadConfig()`
+- `branchesPlugin` merges GET response with config via `deepMerge` (from `diff.ts`) before applying — sends full merged payload, not a minimal diff
+- `branchesPlugin` determines `isOrganization` internally by checking the repo owner type
+- `cleanupMergedProtection` for user-owned repos: sets `restrictions = null`, deletes `dismissal_restrictions`, strips org-only `users`/`teams` from `bypass_pull_request_allowances`
+- `resolveStatusCheckConflict()` runs between merge and cleanup — keeps whichever field (`checks` or `contexts`) the config specifies
+- Tests use `createOctokit()` helpers with `vi.fn()` methods, no real API calls
+- Build: `tsup` (not tsc) → single bundled `dist/index.js`
+
+## COMMANDS
+
+```bash
+pnpm build     # tsup → dist/index.js (must commit dist/)
+pnpm test      # vitest run
+pnpm lint      # eslint
+```
+
+## NOTES
+
+- `dist/index.js` is committed — GitHub Actions requires pre-built JS
+- GitHub API returns both `checks` and `contexts` on GET for branch protection — `sanitizeStatusChecks` normalizes this before merge
+- For user-owned repos (non-org), the API rejects non-null `restrictions` and org-only sub-fields in `required_pull_request_reviews`
+- `stripUrlFields` removes `*_url` fields from API responses before comparison
+- `BOOLEAN_PROTECTION_FIELDS` lists branch protection fields that wrap booleans as `{enabled: bool}` objects
+- `repository.ts`: topics use `repos.replaceAllTopics()`, security features use `repos.enableVulnerabilityAlerts()` — not just `repos.update()`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
 # PROJECT KNOWLEDGE BASE
 
-**Generated:** 2026-03-20 **Branch:** main
+**Generated:** 2026-04-03
+**Branch:** main
 
 ## OVERVIEW
 
@@ -12,17 +13,18 @@ Organization defaults, reusable workflows, custom GitHub Actions, and workflow t
 ./
 ├── .github/
 │   ├── actions/
-│   │   ├── renovate-changesets/   # Complex action: auto-generates changesets for Renovate PRs (125 src files)
+│   │   ├── renovate-changesets/   # Complex action: auto-generates changesets for Renovate PRs (~130 src files)
 │   │   ├── update-metadata/       # Simple action: generates/updates repo metadata (1 src file)
-│   │   └── update-repository-settings/ # Action for updating repository settings (26 src files)
-│   ├── workflows/                 # 17 workflows: CI/CD, Fro Bot agent, Copilot setup
+│   │   └── update-repository-settings/ # Plugin-based action: syncs repo settings from YAML config (34 files)
+│   ├── workflows/                 # 17 workflows: CI/CD, Fro Bot agent, Copilot setup, security scanning
 │   ├── instructions/              # Dev guidelines consumed by AI assistants and code review
 │   └── settings.yml               # Repo settings via Repository Settings App
 ├── workflow-templates/            # Org-wide workflow templates (with .properties.json metadata)
 ├── scripts/                       # TypeScript utilities (tsx): release, build perf, workspace validation
-├── docs/workflows/                # Workflow documentation and troubleshooting
+├── docs/
+│   ├── workflows/                 # Workflow documentation and troubleshooting
+│   └── solutions/                 # Solved-problem documentation (learnings, patterns)
 ├── metadata/                      # Renovate config shared across org repos
-├── .ai/plan/                      # AI implementation plans (not code)
 ├── common-settings.yaml           # Org-wide repo settings and labels
 └── profile/                       # GitHub org profile README
 ```
@@ -41,7 +43,7 @@ Organization defaults, reusable workflows, custom GitHub Actions, and workflow t
 | Add/edit automation script | `scripts/` | Use `#!/usr/bin/env tsx`. Follow existing patterns |
 | Change org-wide Renovate config | `metadata/renovate.yaml` | Inherited by all org repos |
 | Change THIS repo's Renovate config | `.github/renovate.json5` | Extends bfra-me/renovate-config |
-| Edit repo settings | `.github/settings.yml` + `common-settings.yaml` | Applied by elstudio/actions-settings |
+| Edit repo settings | `.github/settings.yml` + `common-settings.yaml` | Applied by update-repository-settings action |
 | Add dev guidelines | `.github/instructions/` | `*.instructions.md` format |
 | Release | `scripts/release.ts` | Multi-package tagging: private=`v{ver}`, public=`{name}@{ver}` |
 
@@ -55,8 +57,9 @@ Organization defaults, reusable workflows, custom GitHub Actions, and workflow t
 - **GitHub App auth** — `bfra-me[bot]` via `actions/create-github-app-token` for automated workflows
 - **120 char line limit** — enforced via `.editorconfig`
 - **2-space indent** — for TS/JS/JSON/YAML/Markdown
-- **Vitest exclusively** — no Jest. Coverage thresholds: 80% statements/branches/functions/lines
+- **Vitest exclusively** — no Jest. Coverage thresholds: 80% statements/functions/lines, 75% branches
 - **Workspace scripts via tsx** — `#!/usr/bin/env tsx`, function-based, typed with interfaces
+- **Self-checkout pattern** — reusable workflows that call internal actions use `GITHUB_WORKFLOW_REF` to resolve the correct ref for cross-repo checkout (not `github.workflow_sha`, which resolves to the caller's SHA)
 
 ## ANTI-PATTERNS (THIS PROJECT)
 
@@ -67,6 +70,7 @@ Organization defaults, reusable workflows, custom GitHub Actions, and workflow t
 - `contexts` in branch protection — deprecated, use `checks` instead
 - Cancelling Renovate jobs that push to main
 - `@ts-ignore` / `as any` — strict TypeScript enforced
+- `github.workflow_sha` for cross-repo checkout — resolves to caller's SHA in `workflow_call`; use `GITHUB_WORKFLOW_REF` instead
 
 ## COMMANDS
 
@@ -88,9 +92,11 @@ pnpm run build:monitor            # Build performance analysis
 - `dist/` directories are committed for actions (GitHub requires pre-built JS)
 - Root `tsconfig.json` uses `noEmit: true` — type-checking only. Actions have own build configs
 - HACK in `scripts/release.ts`: monorepo root tagged as `{name}@{ver}` format (workaround)
+- All actions use Node.js 24 runtime (`using: node24` in action manifests)
 
 - `.github/instructions/` files are consumed by AI tools, not by build system
-- `pnpm` override: `jiti` pinned to `<2.7.0` due to compatibility issue
+- `pnpm` overrides: `jiti` pinned to `<2.7.0` (compatibility), `undici@<6.23.0` forced to `>=6.23.0`
 - Fro Bot uses `FRO_BOT_PAT` + `OPENCODE_AUTH_JSON` secrets (separate from `bfra-me[bot]` app)
 - Fro Bot org autoheal runs weekdays; repo autoheal runs daily; oversight report runs daily
 - `copilot-instructions.md` references AGENTS.md — keep both in sync
+- Reusable workflows resolve action code via self-checkout at `GITHUB_WORKFLOW_REF` — no hardcoded SHA pins needed for internal actions


### PR DESCRIPTION
## Summary

- **Root `AGENTS.md`** — refreshed with accuracy fixes and new architecture context
- **`.github/actions/update-repository-settings/AGENTS.md`** — new file documenting plugin-based architecture

## Root changes

- Fix coverage thresholds: 80% statements/functions/lines, **75% branches** (was incorrectly 80%)
- Add `docs/solutions/` to structure tree
- Document `GITHUB_WORKFLOW_REF` self-checkout pattern in CONVENTIONS
- Add `github.workflow_sha` misuse to ANTI-PATTERNS
- Note Node.js 24 runtime for all actions
- Note `GITHUB_WORKFLOW_REF`-based action resolution (no hardcoded SHA pins)

## New: update-repository-settings AGENTS.md

- Plugin architecture: registry, `applySettings()` orchestration, per-resource-type plugins
- Branch protection conventions: `cleanupMergedProtection` (org vs user repos), `resolveStatusCheckConflict()`
- Config loading: `_extends` for remote YAML inheritance
- WHERE TO LOOK table for common tasks
- API quirks: checks/contexts mutual exclusivity, user-repo field restrictions, separate endpoints for topics/security

## Oracle review

All claims spot-checked against actual code. Fixes applied per Oracle feedback:
- Plugin signature corrected to 4 params (was incorrectly 5)
- `cleanupMergedProtection` behavior corrected for user repos (strips org-only fields, doesn't delete `bypass_pull_request_allowances` entirely)
- `diffCollections` return values corrected (add/update/remove, not create/update/delete)
- Added missing `repository.ts` topics/security endpoints note