### PR TITLE
fix: broaden bot actor filter in renovate-changeset workflow

### DIFF
--- a/.changeset/fix-bot-actor-filter.md
+++ b/.changeset/fix-bot-actor-filter.md
@@ -1,0 +1,5 @@
+---
+"@bfra.me/.github": patch
+---
+
+Broaden bot actor filter in `renovate-changeset` workflow to accept any GitHub App bot, not just `bfra-me[bot]` and `renovate[bot]`.

--- a/.github/workflows/renovate-changeset.yaml
+++ b/.github/workflows/renovate-changeset.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     if: >-
       (github.repository == 'bfra-me/.github' || github.event_name == 'workflow_call') &&
-      (github.actor == 'bfra-me[bot]' || github.actor == 'renovate[bot]') &&
+      endsWith(github.actor, '[bot]') &&
       !startsWith(github.head_ref, 'chore/update-action-pins-')
     steps:
       - id: get-workflow-access-token


### PR DESCRIPTION
## Summary

The `renovate-changeset` reusable workflow hardcodes `bfra-me[bot]` and `renovate[bot]` in its `if` condition. When called via `workflow_call` from repos using other GitHub App bots (e.g. `mrbro-bot[bot]`), the job is **silently skipped** — no error, no changeset.

Reported in https://github.com/marcusrbrown/infra/pull/9#pullrequestreview-4054616057

## Fix

Replace:
```yaml
(github.actor == 'bfra-me[bot]' || github.actor == 'renovate[bot]')
```

With:
```yaml
endsWith(github.actor, '[bot]')
```

Only GitHub App installations have the `[bot]` suffix, so this is safe. The calling workflow controls which specific actors trigger it via its own `if` condition — the reusable workflow shouldn't duplicate that gating.