### PR TITLE
fix: remove job-level permissions from renovate-changeset workflow

### DIFF
--- a/.changeset/fix-renovate-changeset-permissions.md
+++ b/.changeset/fix-renovate-changeset-permissions.md
@@ -1,0 +1,5 @@
+---
+"@bfra.me/.github": patch
+---
+
+Remove job-level permissions from renovate-changeset reusable workflow to fix `startup_failure` when callers set restrictive workflow-level permissions.

--- a/.github/workflows/renovate-changeset.yaml
+++ b/.github/workflows/renovate-changeset.yaml
@@ -19,9 +19,6 @@ permissions:
 jobs:
   create-changeset:
     name: Create Renovate Changeset
-    permissions:
-      contents: write
-      pull-requests: write
     runs-on: ubuntu-latest
     if: >-
       (github.repository == 'bfra-me/.github' || github.event_name == 'workflow_call') &&


### PR DESCRIPTION
## Summary

- Remove `permissions: { contents: write, pull-requests: write }` from the `create-changeset` job in the `renovate-changeset.yaml` reusable workflow

## Problem

When a caller workflow sets restrictive permissions (e.g. `permissions: contents: read`), GitHub validates that the reusable workflow's job cannot request more permissive scopes. The `create-changeset` job requested `contents: write, pull-requests: write`, causing an immediate `startup_failure`:

> Error calling workflow '...renovate-changeset.yaml@969b04c4...'. The nested job 'create-changeset' is requesting 'contents: write, pull-requests: write', but is only allowed 'contents: read, pull-requests: none'.

## Fix

Remove the job-level `permissions` block entirely. The job-level permissions were unnecessary — every step that writes (checkout, commit-back, PR operations) uses the **GitHub App token** from `actions/create-github-app-token`, not `GITHUB_TOKEN`. The workflow-level `permissions: contents: read` is sufficient.

## Evidence

- `marcusrbrown/infra` runs: [23958024278](https://github.com/marcusrbrown/infra/actions/runs/23958024278), [23952443362](https://github.com/marcusrbrown/infra/actions/runs/23952443362) — both `startup_failure`
- Same SHA (`969b04c4`) works fine for `update-repo-settings.yaml` (which has no job-level permissions)