### PR TITLE
ci(renovate): add internal Renovate config preset

### DIFF
--- a/.changeset/cozy-insects-drum.md
+++ b/.changeset/cozy-insects-drum.md
@@ -1,0 +1,6 @@
+---
+"@bfra.me/.github": minor
+---
+
+Add `internal` Renovate config preset to roll up org config.
+  

--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -41,6 +41,7 @@ renovate:
       - any-glob-to-any-file:
           - .github/workflows/*renovate*.yaml
           - .github/renovate.json5
+          - internal.json5
 
 scripts:
   - changed-files:

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,15 +1,8 @@
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
-  extends: [
-    'github>bfra-me/renovate-config#5.2.1',
-    'github>bfra-me/renovate-config:fro-bot.json5#5.2.1',
-  ],
+  extends: ['local>bfra-me/.github:internal.json5'],
   automergeType: 'pr',
   packageRules: [
-    {
-      matchDepNames: ['python'],
-      allowedVersions: '<=3.13',
-    },
     {
       matchPackageNames: ['aquasecurity/trivy-action'],
       versioning: 'github-releases',
@@ -23,28 +16,6 @@
       description: 'Disable Mise updates - workaround Renovate error due to no `tools` key.',
       matchManagers: ['mise'],
       enabled: false,
-    },
-    {
-      description: 'Disable digest-only updates for internal bfra-me/.github actions to stop recursive self-referencing PRs.',
-      matchDepNames: ['bfra-me/.github'],
-      matchUpdateTypes: ['digest'],
-      enabled: false,
-    },
-    {
-      description: 'Track released versions of renovate-changesets action via release tags.',
-      matchDepNames: ['bfra-me/.github'],
-      matchFileNames: ['.github/workflows/renovate-changeset.yaml'],
-      extractVersion: '^renovate-changesets@(?<version>.+)$',
-      pinDigests: false,
-      commitMessageTopic: 'renovate-changesets action',
-    },
-    {
-      description: 'Track released versions of update-repository-settings action via release tags.',
-      matchDepNames: ['bfra-me/.github'],
-      matchFileNames: ['.github/workflows/update-repo-settings.yaml'],
-      extractVersion: '^update-repository-settings@(?<version>.+)$',
-      pinDigests: false,
-      commitMessageTopic: 'update-repository-settings action',
     },
   ],
   postUpgradeTasks: {

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -89,7 +89,7 @@ jobs:
       )
     env:
       WORKFLOW_LOG_LEVEL: debug
-      default_path_filters: "['.github/workflows/renovate.yaml', '.github/renovate.json5']"
+      default_path_filters: "['.github/workflows/renovate.yaml', '.github/renovate.json5', 'internal.json5']"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/internal.json5
+++ b/internal.json5
@@ -1,0 +1,37 @@
+{
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  extends: [
+    'github>bfra-me/renovate-config#5.2.1',
+    'github>bfra-me/renovate-config:fro-bot.json5#5.2.1',
+  ],
+  automergeType: 'pr',
+  packageRules: [
+    {
+      matchDepNames: ['python'],
+      allowedVersions: '<=3.13',
+    },
+    {
+      description: 'Disable digest-only updates for internal bfra-me/.github actions to stop recursive self-referencing PRs.',
+      matchDepNames: ['bfra-me/.github'],
+      matchUpdateTypes: ['digest'],
+      enabled: false,
+    },
+    {
+      description: 'Track released versions of renovate-changesets action via release tags.',
+      matchDepNames: ['bfra-me/.github'],
+      matchFileNames: ['.github/workflows/renovate-changeset.yaml'],
+      extractVersion: '^renovate-changesets@(?<version>.+)$',
+      pinDigests: false,
+      commitMessageTopic: 'renovate-changesets action',
+    },
+    {
+      description: 'Track released versions of update-repository-settings action via release tags.',
+      matchDepNames: ['bfra-me/.github'],
+      matchFileNames: ['.github/workflows/update-repo-settings.yaml'],
+      extractVersion: '^update-repository-settings@(?<version>.+)$',
+      pinDigests: false,
+      commitMessageTopic: 'update-repository-settings action',
+    },
+  ],
+  rebaseWhen: 'behind-base-branch',
+}


### PR DESCRIPTION
- Introduced `internal.json5` for organization-wide Renovate configuration.
- Updated `renovate.yaml` to include `internal.json5` in path filters.
- Modified `renovate.json5` to extend from the new internal config.
- Added `internal` preset to roll up organization configuration.