### PR TITLE
fix(renovate-changesets): include private workspace roots in package name resolution

### DIFF
--- a/.changeset/fix-root-package-name.md
+++ b/.changeset/fix-root-package-name.md
@@ -1,0 +1,5 @@
+---
+"renovate-changesets": patch
+---
+
+Fix `getRootPackageName` to include private workspace roots in the resolution order, reverting the #2012 regression that caused changesets to use the repo slug (`.github`) instead of the root package name (`@bfra.me/.github`).

--- a/.changeset/renovate-3db3a2e.md
+++ b/.changeset/renovate-3db3a2e.md
@@ -1,5 +1,5 @@
 ---
-'.github': patch
+'@bfra.me/.github': patch
 ---
 
 ⚠️ Update GitHub Actions workflow dependency `fro-bot/agent` from `v0.38.0` to `v0.39.0`

--- a/.changeset/renovate-b79c70f.md
+++ b/.changeset/renovate-b79c70f.md
@@ -1,5 +1,5 @@
 ---
-'.github': patch
+'@bfra.me/.github': patch
 ---
 
 ⚙️ Update GitHub Actions workflow dependency `bfra-me/renovate-action` from `9.34.0` to `9.35.0`

--- a/.github/actions/renovate-changesets/src/run-generation-helpers.ts
+++ b/.github/actions/renovate-changesets/src/run-generation-helpers.ts
@@ -6,12 +6,10 @@ import {extractDependenciesFromTitle} from './utils'
  * Resolve the changeset release target when no workspace member is directly affected
  * (e.g. `github-actions` updates that only touch `.github/workflows/*.yaml`).
  *
- * Resolution order: explicit `targetPackage` override → non-private workspace root →
- * first non-private workspace member → `fallbackName`. Private workspace roots are
- * skipped because `@manypkg/get-packages` only includes them when `.` is in the
- * workspace patterns; targeting one produces a changeset that crashes
- * `changeset version` with "Found changeset X for package Y which is not in the
- * workspace" (see issue #2012).
+ * Resolution order: explicit `targetPackage` override → workspace root (regardless of
+ * private status) → first non-private workspace member → `fallbackName`. If a root
+ * package exists in `workspacePackages`, it was discovered by the workspace analyzer
+ * and is a valid changeset target.
  */
 export function getRootPackageName(
   workspacePackages: WorkspacePackage[],
@@ -23,9 +21,7 @@ export function getRootPackageName(
     return explicit?.name ?? targetPackage
   }
 
-  const rootPackage = workspacePackages.find(
-    pkg => (pkg.path === '.' || pkg.path === '') && !pkg.private,
-  )
+  const rootPackage = workspacePackages.find(pkg => pkg.path === '.' || pkg.path === '')
   if (rootPackage != null) return rootPackage.name
 
   const firstPublic = workspacePackages.find(pkg => !pkg.private)

--- a/.github/actions/renovate-changesets/test/run-generation-helpers.test.ts
+++ b/.github/actions/renovate-changesets/test/run-generation-helpers.test.ts
@@ -28,14 +28,14 @@ describe('getRootPackageName', () => {
       expect(getRootPackageName(packages, 'fallback')).toBe('@scope/root')
     })
 
-    it('returns the first non-private workspace member when the root is private (issue #2012)', () => {
+    it('returns the workspace root even when it is private', () => {
       const packages: WorkspacePackage[] = [
         makePackage({name: '@scope/repo-workspace', path: '.', private: true}),
         makePackage({name: '@scope/keeweb', path: 'apps/keeweb', private: true}),
         makePackage({name: '@scope/cli', path: 'packages/cli', private: false}),
       ]
 
-      expect(getRootPackageName(packages, 'fallback')).toBe('@scope/cli')
+      expect(getRootPackageName(packages, 'fallback')).toBe('@scope/repo-workspace')
     })
 
     it('returns the first non-private package even when no root entry exists', () => {
@@ -47,13 +47,13 @@ describe('getRootPackageName', () => {
       expect(getRootPackageName(packages, 'fallback')).toBe('@scope/lib')
     })
 
-    it('returns the fallback when all workspace packages are private', () => {
+    it('returns the private root when all workspace packages are private', () => {
       const packages: WorkspacePackage[] = [
         makePackage({name: '@scope/repo-workspace', path: '.', private: true}),
         makePackage({name: '@scope/internal', path: 'packages/internal', private: true}),
       ]
 
-      expect(getRootPackageName(packages, 'owner/repo')).toBe('owner/repo')
+      expect(getRootPackageName(packages, 'owner/repo')).toBe('@scope/repo-workspace')
     })
 
     it('returns the fallback when no workspace packages are discovered', () => {
@@ -94,7 +94,7 @@ describe('getRootPackageName', () => {
         makePackage({name: '@scope/cli', path: 'packages/cli', private: false}),
       ]
 
-      expect(getRootPackageName(packages, 'fallback', '')).toBe('@scope/cli')
+      expect(getRootPackageName(packages, 'fallback', '')).toBe('@scope/repo-workspace')
     })
 
     it('takes precedence over a non-private root', () => {


### PR DESCRIPTION
## Summary

- Fix `getRootPackageName` to include private workspace roots, reverting the #2012 regression
- Fix two existing changesets with incorrect `.github` package name → `@bfra.me/.github`

## Problem

#2012 added a `!pkg.private` filter to `getRootPackageName`, causing workflow-only Renovate PRs to generate changesets with `.github` (repo slug) instead of `@bfra.me/.github` (root package name). This broke the release PR:

> https://github.com/bfra-me/.github/actions/runs/24323531361/job/71014167105

The `!pkg.private` guard was overly conservative — if a root package exists in `workspacePackages`, it was already discovered by the workspace analyzer and is a valid changeset target.

## Changes

- **`src/run-generation-helpers.ts`**: Remove `!pkg.private` from root package check. Updated JSDoc to document new resolution order
- **`test/run-generation-helpers.test.ts`**: Updated 3 tests to expect private root name instead of first non-private member or fallback
- **`.changeset/renovate-b79c70f.md`** and **`.changeset/renovate-3db3a2e.md`**: Fixed `'.github'` → `'@bfra.me/.github'`

## Evidence

- 503 tests pass
- Build succeeds (`dist/index.js` regenerated)