### PR TITLE
chore: bump TS/esbuild target to ES2024/node24, add engines field

### DIFF
--- a/.changeset/node24-ts-target.md
+++ b/.changeset/node24-ts-target.md
@@ -1,0 +1,7 @@
+---
+'renovate-changesets': patch
+'update-repository-settings': patch
+'update-metadata': patch
+---
+
+Bump TypeScript build target to ES2024 and esbuild target to node24 to match the Node.js 24 runtime. Add `engines: { node: ">=24" }` to all action packages. Fix deprecated `import ... assert` → `import ... with` syntax in tsup configs.

--- a/.github/actions/renovate-changesets/package.json
+++ b/.github/actions/renovate-changesets/package.json
@@ -40,5 +40,8 @@
     "@types/js-yaml": "4.0.9",
     "@types/node": "24.12.0",
     "tsup": "8.5.1"
+  },
+  "engines": {
+    "node": ">=24"
   }
 }

--- a/.github/actions/renovate-changesets/tsconfig.build.json
+++ b/.github/actions/renovate-changesets/tsconfig.build.json
@@ -12,7 +12,7 @@
     // Performance optimizations for incremental builds
     "assumeChangesOnlyAffectDirectDependencies": true,
 
-    "target": "ES2022",
+    "target": "ES2024",
     "rootDir": "src",
 
     "module": "Preserve",

--- a/.github/actions/renovate-changesets/tsup.config.ts
+++ b/.github/actions/renovate-changesets/tsup.config.ts
@@ -1,5 +1,5 @@
 import type {Options} from 'tsup'
-import packageJson from './package.json' assert {type: 'json'}
+import packageJson from './package.json' with {type: 'json'}
 
 const config: Options = {
   banner: {
@@ -9,6 +9,7 @@ const config: Options = {
     index: 'src/index.ts',
   },
   format: 'esm',
+  target: 'node24',
   noExternal: Object.keys(packageJson.dependencies),
   splitting: false,
 }

--- a/.github/actions/update-metadata/package.json
+++ b/.github/actions/update-metadata/package.json
@@ -20,5 +20,8 @@
     "@types/js-yaml": "4.0.9",
     "@types/node": "24.12.0",
     "tsup": "8.5.1"
+  },
+  "engines": {
+    "node": ">=24"
   }
 }

--- a/.github/actions/update-metadata/tsconfig.build.json
+++ b/.github/actions/update-metadata/tsconfig.build.json
@@ -12,7 +12,7 @@
     // Performance optimizations for incremental builds
     "assumeChangesOnlyAffectDirectDependencies": true,
 
-    "target": "ES2022",
+    "target": "ES2024",
     "rootDir": "src",
 
     "module": "Preserve",

--- a/.github/actions/update-metadata/tsup.config.ts
+++ b/.github/actions/update-metadata/tsup.config.ts
@@ -1,5 +1,5 @@
 import type {Options} from 'tsup'
-import packageJson from './package.json' assert {type: 'json'}
+import packageJson from './package.json' with {type: 'json'}
 
 const config: Options = {
   banner: {
@@ -9,6 +9,7 @@ const config: Options = {
     index: 'src/index.ts',
   },
   format: 'esm',
+  target: 'node24',
   noExternal: Object.keys(packageJson.dependencies),
 }
 

--- a/.github/actions/update-repository-settings/package.json
+++ b/.github/actions/update-repository-settings/package.json
@@ -21,5 +21,8 @@
     "@types/js-yaml": "4.0.9",
     "@types/node": "24.12.0",
     "tsup": "8.5.1"
+  },
+  "engines": {
+    "node": ">=24"
   }
 }

--- a/.github/actions/update-repository-settings/tsconfig.build.json
+++ b/.github/actions/update-repository-settings/tsconfig.build.json
@@ -7,7 +7,7 @@
     "composite": true,
     "tsBuildInfoFile": ".tsbuildinfo",
     "assumeChangesOnlyAffectDirectDependencies": true,
-    "target": "ES2022",
+    "target": "ES2024",
     "rootDir": "src",
     "module": "Preserve",
     "moduleResolution": "Bundler",

--- a/.github/actions/update-repository-settings/tsup.config.ts
+++ b/.github/actions/update-repository-settings/tsup.config.ts
@@ -1,5 +1,5 @@
 import type {Options} from 'tsup'
-import packageJson from './package.json' assert {type: 'json'}
+import packageJson from './package.json' with {type: 'json'}
 
 const config: Options = {
   banner: {
@@ -9,6 +9,7 @@ const config: Options = {
     index: 'src/index.ts',
   },
   format: 'esm',
+  target: 'node24',
   noExternal: Object.keys(packageJson.dependencies),
 }
 


### PR DESCRIPTION
## Summary

Aligns TypeScript and esbuild build targets with the Node.js 24 runtime declared in all action manifests. Adds explicit `engines` constraints.

## Changes

**TypeScript target (tsconfig.build.json):**
- `ES2022` → `ES2024` in all 3 actions

**esbuild target (tsup.config.ts):**
- Added `target: 'node24'` in all 3 actions (previously inherited `es2022` default from tsconfig.json)
- Fixed deprecated `import ... assert` → `import ... with` syntax (import attributes replaced import assertions)

**engines (package.json):**
- Added `"engines": {"node": ">=24"}` to all 3 action packages

## Verification

- `pnpm run quality-check` passes: type-check ✅ lint ✅ build ✅ 641 tests ✅
- Build output confirms `Target: node24` (previously showed `es2022`)