### PR TITLE
fix(update-repo-settings): use full history on push to fix paths-filter exit 128

### DIFF
--- a/.changeset/fix-update-repo-settings-fetch-depth.md
+++ b/.changeset/fix-update-repo-settings-fetch-depth.md
@@ -1,0 +1,5 @@
+---
+'@bfra.me/.github': patch
+---
+
+Fix intermittent `git exit 128` in the `update-repo-settings` reusable workflow's `Filter Changed Files` step on push events. The push-event checkout now uses `fetch-depth: 0` so `dorny/paths-filter` always has the history it needs to diff against the parent commit, instead of the default shallow clone that could fail the diff.

--- a/.github/workflows/update-repo-settings.yaml
+++ b/.github/workflows/update-repo-settings.yaml
@@ -30,6 +30,11 @@ jobs:
       - if: github.event_name == 'push'
         name: Checkout Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # Full history so dorny/paths-filter can diff against the parent
+          # commit on push events; the default shallow clone (fetch-depth: 1)
+          # intermittently fails the diff with git exit 128 (#2213).
+          fetch-depth: 0
 
       - id: filter
         if: github.event_name == 'push'


### PR DESCRIPTION
## What

Fix the intermittent `git failed with exit code 128` in the `update-repo-settings` reusable workflow's `Filter Changed Files` step on push events.

Closes #2213.

## Root cause

On `push`, the workflow checks out with `actions/checkout` at its default `fetch-depth: 1` (shallow), then runs `dorny/paths-filter`, which diffs `github.event.before` against `github.sha`. When the parent commit isn't in the shallow clone, paths-filter's internal `git` operation fails with exit 128. It's `push`-only (the steps gate on `github.event_name == 'push'`), which is why `workflow_dispatch` always succeeds and the failures are intermittent — they depend on whether the parent commit happens to be reachable.

## Fix

Set `fetch-depth: 0` on the push-event checkout so the diff always has the history it needs. Boring and robust against rebases, force-pushes, and large squashes (`fetch-depth: 2` would cover typical merge commits but not those edge cases).

```yaml
- if: github.event_name == 'push'
  name: Checkout Repository
  uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
  with:
    fetch-depth: 0
```

## Impact

Caller repos consuming this reusable workflow stop seeing red CI on unrelated push events. They pick up the fix on their next pin bump.

## Verification

- `update-repo-settings.yaml` parses as valid YAML; lint clean.
- Patch changeset added (`@bfra.me/.github`) — reusable workflow change is root-scoped.
