### PR TITLE
docs(instructions): note shallow-checkout paths-filter push gotcha

### DIFF
--- a/.github/instructions/github-actions.instructions.md
+++ b/.github/instructions/github-actions.instructions.md
@@ -129,6 +129,7 @@ applyTo: '.github/workflows/*.yaml,.github/actions/**/*'
   - **Edge cases to be aware of when using GitHub Actions**: Handling rate limits, managing concurrency, and dealing with transient network errors.
   - **Version-specific issues with GitHub Actions**: Changes in action syntax, deprecation of features, and compatibility issues with older runner environments.
   - **Compatibility concerns between GitHub Actions and other technologies**: Ensuring that actions are compatible with the target operating systems, programming languages, and cloud platforms.
+  - **Shallow checkout breaks change detection on push**: `actions/checkout` defaults to a shallow clone (`fetch-depth: 1`). Steps that diff against the parent commit on push events — e.g. `dorny/paths-filter` comparing `github.event.before` to `github.sha` — then fail intermittently with `git failed with exit code 128`. Set `fetch-depth: 0` on the push-event checkout. See [docs/solutions/integration-issues/shallow-checkout-breaks-paths-filter-on-push-events-2026-06-25.md](/docs/solutions/integration-issues/shallow-checkout-breaks-paths-filter-on-push-events-2026-06-25.md).
 
 - **Best Practices specific for Docker containers**
   - **Minimize image size**: Utilize multi-stage builds to reduce the final image size, include only required dependencies, and remove unnecessary files.


### PR DESCRIPTION
## What

Add a "Common Pitfalls" bullet to the GitHub Actions instructions warning that a default shallow checkout breaks push-event change detection, cross-linking the solution doc.

## Why

`actions/checkout` defaults to `fetch-depth: 1`. Steps that diff against the parent commit on push (e.g. `dorny/paths-filter`) then fail intermittently with `git exit 128` — the exact bug fixed in #2346 (#2213). Surfacing it as proactive guidance in the instructions file means the next author reaches for `fetch-depth: 0` before hitting the failure, instead of after.

## Changes

- `.github/instructions/github-actions.instructions.md`: one bullet under **Common Pitfalls and Gotchas**, linking `docs/solutions/integration-issues/shallow-checkout-breaks-paths-filter-on-push-events-2026-06-25.md`.

## Verification

- Lint clean; lint-staged clean on commit. Documentation-only.
