### PR TITLE
fix(renovate): remove `timeout-minutes` from Renovate job

### DIFF
--- a/.changeset/petite-pears-glow.md
+++ b/.changeset/petite-pears-glow.md
@@ -1,0 +1,6 @@
+---
+"@bfra.me/.github": patch
+---
+
+Remove `timeout-minutes` from reusable Renovate workflow.
+  

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -175,4 +175,3 @@ jobs:
           print-config: ${{ inputs.print-config }}
           renovate-app-id: ${{ secrets.APPLICATION_ID }}
           renovate-app-private-key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
-    timeout-minutes: 30


### PR DESCRIPTION
In repositories with many Renovate update branches, Renovate can run longer than 30 minutes.