### PR TITLE
ci(renovate): hold typescript below v7 until typescript-eslint supports it

### DIFF
--- a/.changeset/hold-typescript-v7.md
+++ b/.changeset/hold-typescript-v7.md
@@ -1,0 +1,5 @@
+---
+'@bfra.me/.github': patch
+---
+
+⏸️ Hold TypeScript below v7 until typescript-eslint supports TypeScript 7.

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -17,6 +17,12 @@
       matchManagers: ['mise'],
       enabled: false,
     },
+    {
+      description: 'Hold TypeScript below v7 because typescript-eslint lacks TS7 support; remove once support lands.',
+      matchDatasources: ['npm'],
+      matchPackageNames: ['typescript'],
+      allowedVersions: '<7',
+    },
   ],
   postUpgradeTasks: {
     commands: ['pnpm run bootstrap', 'pnpm run build', 'pnpm run fix'],


### PR DESCRIPTION
TypeScript 7 breaks linting here, and there is no version of typescript-eslint that fixes it.

`@typescript-eslint/parser` throws `TypeError: Cannot read properties of undefined (reading 'Cjs')` under TS 7.0.2, and the latest release (8.67.0) still declares `peerDependencies.typescript: ">=4.8.4 <6.1.0"`. No published version supports TS 7 yet, so there is no pin or config change on our side that makes Quality Check pass.

Renovate opened #2526 and #2527 for this bump and both failed. I closed them, but without a hold Renovate just regenerates the PR every cycle. This adds an `allowedVersions: '<7'` rule so it stops.

Remove the rule once typescript-eslint ships TS 7 support — the `description` field says so inline.

Verified with `renovate-config-validator`: `Config validated successfully against 1 file(s)`.
