### PR TITLE
chore(renovate-changesets): fix strict-null test access

### DIFF
--- a/.github/actions/renovate-changesets/test/action-config.test.ts
+++ b/.github/actions/renovate-changesets/test/action-config.test.ts
@@ -15,19 +15,19 @@ describe('action-config', () => {
 
     it('should include github-actions update type with correct file patterns', () => {
       expect(DEFAULT_CONFIG.updateTypes['github-actions']).toBeDefined()
-      expect(DEFAULT_CONFIG.updateTypes['github-actions'].filePatterns).toContain(
+      expect(DEFAULT_CONFIG.updateTypes['github-actions']?.filePatterns).toContain(
         '.github/workflows/**/*.yaml',
       )
     })
 
     it('should include npm update type with package.json pattern', () => {
       expect(DEFAULT_CONFIG.updateTypes.npm).toBeDefined()
-      expect(DEFAULT_CONFIG.updateTypes.npm.filePatterns).toContain('**/package.json')
+      expect(DEFAULT_CONFIG.updateTypes.npm?.filePatterns).toContain('**/package.json')
     })
 
     it('should include docker update type', () => {
       expect(DEFAULT_CONFIG.updateTypes.docker).toBeDefined()
-      expect(DEFAULT_CONFIG.updateTypes.docker.filePatterns).toContain('**/Dockerfile')
+      expect(DEFAULT_CONFIG.updateTypes.docker?.filePatterns).toContain('**/Dockerfile')
     })
 
     it('should have defaultChangesetType of patch', () => {

--- a/.github/actions/renovate-changesets/test/deduplicator.test.ts
+++ b/.github/actions/renovate-changesets/test/deduplicator.test.ts
@@ -232,7 +232,7 @@ describe('duplicate-strategies', () => {
 
       expect(result.unique).toHaveLength(1)
       expect(result.duplicates).toHaveLength(1)
-      expect(result.unique[0].id).toBe('cs1')
+      expect(result.unique[0]?.id).toBe('cs1')
     })
 
     it('should handle empty input', () => {


### PR DESCRIPTION
`pnpm run type-check` at the repo root does not cover the action packages' `test/` directories. Running `npx tsc --noEmit` from inside `.github/actions/renovate-changesets/` does, and it has been reporting four strict-null errors for long enough that "expect exactly 4 pre-existing errors" became a standing caveat on every verification pass — the kind of noise that eventually hides a real error.

All four are the same shape: `expect(x).toBeDefined()` proves the value exists to a human but does not narrow the type for TypeScript, so the next line's property access is flagged.

```
test/action-config.test.ts(18,14): error TS2532: Object is possibly 'undefined'.
test/action-config.test.ts(25,14): error TS18048: 'DEFAULT_CONFIG.updateTypes.npm' is possibly 'undefined'.
test/action-config.test.ts(30,14): error TS18048: 'DEFAULT_CONFIG.updateTypes.docker' is possibly 'undefined'.
test/deduplicator.test.ts(235,14): error TS2532: Object is possibly 'undefined'.
```

Fixed with optional chaining, matching the convention already used in 35 places across this suite. The preceding `toBeDefined()` and `toHaveLength()` assertions stay exactly as they were — they are what makes the optional chain safe, and dropping them would weaken the tests.

`npx tsc --noEmit -p tsconfig.json` from the action directory now exits 0.

Four lines across two test files. No source changes, no `dist` rebuild, no changeset — nothing here ships.