### PR TITLE
chore: ignore coverage output at any depth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ tsconfig.tsbuildinfo
 .specstory/
 
 # Coverage reports
-.github/actions/*/coverage/
+coverage/
 
 .build-performance/
 


### PR DESCRIPTION
`.gitignore` only ignored `.github/actions/*/coverage/`, but the root `vitest.config.ts` also configures `html` and `json` coverage reporters and writes them to `coverage/` at the repository root. Running `pnpm test --coverage` from the root therefore left 96 untracked files behind — enough noise that `gh pr create` warns about uncommitted changes, and close enough to a real staging mistake to be worth closing.

Replacing the pattern with a bare `coverage/` ignores any directory of that name at any depth, so it covers both the root output and every action package. Verified both ways: `git check-ignore` resolves each path to this rule, and a real `pnpm test --project renovate-changesets --coverage` run now leaves the working tree clean.

One line. No changeset — nothing here ships.