### PR TITLE
test(renovate-changesets): add consumer contract harness

### DIFF
--- a/.github/actions/renovate-changesets/AGENTS.md
+++ b/.github/actions/renovate-changesets/AGENTS.md
@@ -91,6 +91,10 @@ pnpm test      # vitest run
 pnpm lint      # eslint
 ```
 
+## CONTRACT TEST PREREQUISITES
+
+`pnpm test --project renovate-changesets-contract` requires `git` on `PATH` and a completed workspace-level `pnpm install`; the test runs the real Changesets CLI from the repository root at `node_modules/@changesets/cli`.
+
 ## NOTES
 
 - `dist/index.js` is committed — GitHub Actions requires pre-built JS.

--- a/.github/actions/renovate-changesets/test/contract/changesets-oracle.ts
+++ b/.github/actions/renovate-changesets/test/contract/changesets-oracle.ts
@@ -1,0 +1,121 @@
+import {spawnSync} from 'node:child_process'
+import {promises as fs} from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+import {fileURLToPath} from 'node:url'
+
+export interface OracleDiagnostics {
+  errors: string[]
+  warnings: string[]
+  outputs: Map<string, string>
+}
+
+export interface ChangesetsOracleResult {
+  releasePlan: {
+    changesets: unknown[]
+    releases: {name: string; type: string}[]
+    [key: string]: unknown
+  }
+  filenames: string[]
+}
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../../')
+const cliPath = path.join(repoRoot, 'node_modules/@changesets/cli/bin.js')
+
+export async function listGeneratedChangesets(workspace: string): Promise<string[]> {
+  const changesetDir = path.join(workspace, '.changeset')
+  const entries = await fs.readdir(changesetDir, {withFileTypes: true})
+  return entries
+    .filter(entry => entry.isFile() && entry.name.endsWith('.md'))
+    .map(entry => `.changeset/${entry.name}`)
+    .sort()
+}
+
+export async function runChangesetsOracle(
+  scenarioName: string,
+  workspace: string,
+  diagnostics: OracleDiagnostics,
+): Promise<ChangesetsOracleResult> {
+  const filenames = await listGeneratedChangesets(workspace)
+  const result = spawnSync(
+    process.execPath,
+    [cliPath, 'status', '--output', '.contract-release-plan.json'],
+    {
+      cwd: workspace,
+      encoding: 'utf8',
+      env: {...process.env, CI: 'true', NO_COLOR: '1'},
+    },
+  )
+
+  if (result.status !== 0) {
+    const contents = await Promise.all(
+      filenames.map(
+        async filename =>
+          [filename, await fs.readFile(path.join(workspace, filename), 'utf8')] as [string, string],
+      ),
+    )
+    throw new Error(
+      formatOracleFailure({
+        scenarioName,
+        exitCode: result.status,
+        stdout: result.stdout,
+        stderr: result.stderr,
+        filenames,
+        contents,
+        diagnostics,
+      }),
+    )
+  }
+
+  const releasePlanPath = path.join(workspace, '.contract-release-plan.json')
+  let releasePlan: ChangesetsOracleResult['releasePlan']
+  try {
+    releasePlan = JSON.parse(
+      await fs.readFile(releasePlanPath, 'utf8'),
+    ) as ChangesetsOracleResult['releasePlan']
+  } catch (error) {
+    throw new Error(
+      formatOracleFailure({
+        scenarioName,
+        exitCode: result.status,
+        stdout: result.stdout,
+        stderr: result.stderr,
+        filenames,
+        contents: [],
+        diagnostics,
+        parseError: error instanceof Error ? error.message : String(error),
+      }),
+    )
+  }
+
+  return {releasePlan, filenames}
+}
+
+function formatOracleFailure(params: {
+  scenarioName: string
+  exitCode: number | null
+  stdout: string
+  stderr: string
+  filenames: string[]
+  contents: [string, string][]
+  diagnostics: OracleDiagnostics
+  parseError?: string
+}): string {
+  const redact = (value: string): string => value.replaceAll('contract-token', '[REDACTED]')
+  return [
+    `Changesets oracle failed for scenario ${params.scenarioName}`,
+    `exit code: ${params.exitCode}`,
+    `stdout:\n${redact(params.stdout)}`,
+    `stderr:\n${redact(params.stderr)}`,
+    params.parseError == null ? '' : `parse error: ${redact(params.parseError)}`,
+    `generated changeset filenames: ${JSON.stringify(params.filenames)}`,
+    `generated changeset contents: ${JSON.stringify(
+      Object.fromEntries(params.contents.map(([filename, content]) => [filename, redact(content)])),
+    )}`,
+    `captured core errors: ${JSON.stringify(params.diagnostics.errors.map(redact))}`,
+    `captured core warnings: ${JSON.stringify(params.diagnostics.warnings.map(redact))}`,
+    `captured outputs: ${JSON.stringify(Object.fromEntries(params.diagnostics.outputs))}`,
+  ]
+    .filter(Boolean)
+    .join('\n')
+}

--- a/.github/actions/renovate-changesets/test/contract/docker-short-sha.contract.test.ts
+++ b/.github/actions/renovate-changesets/test/contract/docker-short-sha.contract.test.ts
@@ -1,0 +1,173 @@
+import {spawnSync} from 'node:child_process'
+import {promises as fs} from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import process from 'node:process'
+import {fileURLToPath} from 'node:url'
+import {afterEach, beforeEach, describe, expect, it} from 'vitest'
+import {run} from '../../src/run.js'
+import {listGeneratedChangesets, runChangesetsOracle} from './changesets-oracle.js'
+import {getContractState, getExecMocks, getOctokitMocks} from './setup.js'
+
+const fixtureRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  'fixtures/marcusrbrown-infra/repo',
+)
+
+let workspace = ''
+const contractState = getContractState()
+const execMocks = getExecMocks()
+const octokitMocks = getOctokitMocks()
+
+describe('renovate-changesets consumer contract', () => {
+  beforeEach(async () => {
+    workspace = await fs.mkdtemp(path.join(os.tmpdir(), 'renovate-changesets-contract-'))
+    await fs.cp(fixtureRoot, workspace, {recursive: true})
+
+    expect(await pathExists(path.join(workspace, 'node_modules'))).toBe(false)
+    initializeGitRepository(workspace)
+
+    process.env.NODE_ENV = 'production'
+    delete process.env.VITEST
+    process.env.GITHUB_EVENT_NAME = 'pull_request_target'
+    process.env.GITHUB_EVENT_PATH = path.join(workspace, 'event.json')
+    process.env.GITHUB_REPOSITORY = 'marcusrbrown/infra'
+    process.env.GITHUB_WORKSPACE = workspace
+    process.env.GITHUB_TOKEN = 'contract-token'
+    delete process.env.BRANCH_PREFIX
+    delete process.env.SKIP_BRANCH_CHECK
+    delete process.env.SORT_CHANGESETS
+    delete process.env.TARGET_PACKAGE
+
+    await fs.writeFile(
+      process.env.GITHUB_EVENT_PATH,
+      JSON.stringify({
+        pull_request: {
+          number: 1103,
+          title: 'chore(deps): update eceasy/cli-proxy-api Docker tag',
+          body: `This PR contains the following updates:\n\n| Package | Update | Change |\n|---|---|---|\n| eceasy/cli-proxy-api | digest | \`0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\` -> \`abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789\` |\n`,
+          user: {login: 'mrbro-bot[bot]'},
+          labels: [{name: 'dependencies'}, {name: 'renovate'}],
+          head: {ref: 'renovate/eceasy-cli-proxy-api-7.x'},
+        },
+      }),
+      'utf8',
+    )
+
+    contractState.inputs = {
+      token: 'contract-token',
+      'working-directory': workspace,
+      'branch-prefix': 'renovate/',
+      'config-file': '',
+      config: '',
+      'default-changeset-type': 'patch',
+      'exclude-patterns': '',
+      'target-package': '',
+      'commit-message-template': 'chore: add changeset for renovate updates',
+      'max-retries': '0',
+      'retry-delay': '100',
+      'max-grouped-prs': '10',
+      'grouped-pr-failure-strategy': 'continue',
+    }
+    contractState.booleanInputs = {
+      'skip-branch-prefix-check': false,
+      sort: false,
+      emoji: false,
+      'comment-pr': false,
+      'update-pr-description': false,
+      'commit-back': false,
+      'auto-resolve-conflicts': true,
+      'update-grouped-prs': false,
+      'skip-current-pr-in-group': true,
+    }
+
+    octokitMocks.listFiles.mockResolvedValue({
+      data: [
+        {
+          filename: 'apps/gateway/Dockerfile',
+          status: 'modified',
+          additions: 1,
+          deletions: 1,
+          patch:
+            '-FROM eceasy/cli-proxy-api:v7.2.134@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\n+FROM eceasy/cli-proxy-api:v7.2.134@sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789',
+        },
+      ],
+    })
+    octokitMocks.listCommits.mockResolvedValue({
+      data: [{commit: {message: 'chore(deps): update eceasy/cli-proxy-api Docker tag'}}],
+    })
+    execMocks.getExecOutput.mockResolvedValue({stdout: 'contract1\n', stderr: '', exitCode: 0})
+  })
+
+  afterEach(async () => {
+    if (workspace.length > 0) await fs.rm(workspace, {recursive: true, force: true})
+    workspace = ''
+  })
+
+  it('generates a Changesets-valid Docker changeset with a short SHA', async () => {
+    await run()
+
+    expect(contractState.failed).toEqual([])
+    expect(contractState.warnings).toContainEqual(
+      expect.stringContaining('@changesets/write failed'),
+    )
+    const filenames = await listGeneratedChangesets(workspace)
+    expect(contractState.outputs.get('changesets-created')).toBe(String(filenames.length))
+    expect(JSON.parse(contractState.outputs.get('changeset-files') ?? 'null')).toEqual(filenames)
+    expect(filenames.length).toBeGreaterThan(0)
+
+    for (const filename of filenames) {
+      const stat = await fs.stat(path.join(workspace, filename))
+      expect(stat.isFile()).toBe(true)
+    }
+
+    const reportedFiles = JSON.parse(
+      contractState.outputs.get('changeset-files') ?? '[]',
+    ) as string[]
+    expect(filenames).toEqual(reportedFiles)
+
+    const oracle = await runChangesetsOracle('docker-short-sha', workspace, {
+      errors: contractState.errors,
+      warnings: contractState.warnings,
+      outputs: contractState.outputs,
+    })
+    expect(oracle.releasePlan.releases.map(({name, type}) => ({name, type}))).toEqual([
+      {name: '@marcusrbrown/infra-gateway', type: 'patch'},
+      {name: '@marcusrbrown/infra-shared', type: 'patch'},
+      {name: '@marcusrbrown/infra-cliproxy', type: 'none'},
+      {name: '@marcusrbrown/infra-vpn', type: 'none'},
+    ])
+  })
+})
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function initializeGitRepository(directory: string): void {
+  for (const args of [
+    ['init', '-b', 'main'],
+    ['add', '.'],
+    [
+      '-c',
+      'user.name=contract-test',
+      '-c',
+      'user.email=contract-test@example.invalid',
+      'commit',
+      '-m',
+      'fixture baseline',
+    ],
+  ]) {
+    const result = spawnSync('git', args, {cwd: directory, encoding: 'utf8'})
+    if (result.status !== 0) {
+      throw new Error(
+        `Failed to initialize fixture git repository: git ${args.join(' ')}\n${result.stderr}`,
+      )
+    }
+  }
+}

--- a/.github/actions/renovate-changesets/test/contract/docker-short-sha.contract.test.ts
+++ b/.github/actions/renovate-changesets/test/contract/docker-short-sha.contract.test.ts
@@ -7,7 +7,7 @@ import {fileURLToPath} from 'node:url'
 import {afterEach, beforeEach, describe, expect, it} from 'vitest'
 import {run} from '../../src/run.js'
 import {listGeneratedChangesets, runChangesetsOracle} from './changesets-oracle.js'
-import {getContractState, getExecMocks, getOctokitMocks} from './setup.js'
+import {getContractState, getOctokitMocks} from './setup.js'
 
 const fixtureRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -16,7 +16,6 @@ const fixtureRoot = path.resolve(
 
 let workspace = ''
 const contractState = getContractState()
-const execMocks = getExecMocks()
 const octokitMocks = getOctokitMocks()
 
 describe('renovate-changesets consumer contract', () => {
@@ -96,7 +95,6 @@ describe('renovate-changesets consumer contract', () => {
     octokitMocks.listCommits.mockResolvedValue({
       data: [{commit: {message: 'chore(deps): update eceasy/cli-proxy-api Docker tag'}}],
     })
-    execMocks.getExecOutput.mockResolvedValue({stdout: 'contract1\n', stderr: '', exitCode: 0})
   })
 
   afterEach(async () => {
@@ -106,7 +104,6 @@ describe('renovate-changesets consumer contract', () => {
 
   it('generates a Changesets-valid Docker changeset with a short SHA', async () => {
     await run()
-
     expect(contractState.failed).toEqual([])
     expect(contractState.warnings).toContainEqual(
       expect.stringContaining('@changesets/write failed'),

--- a/.github/actions/renovate-changesets/test/contract/fixtures/marcusrbrown-infra/repo/.changeset/config.json
+++ b/.github/actions/renovate-changesets/test/contract/fixtures/marcusrbrown-infra/repo/.changeset/config.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
+  "access": "public",
+  "baseBranch": "main",
+  "changelog": false,
+  "commit": false,
+  "fixed": [],
+  "ignore": ["@marcusrbrown/infra-vpn"],
+  "linked": [],
+  "privatePackages": {"tag": true, "version": true},
+  "updateInternalDependencies": "patch"
+}

--- a/.github/actions/renovate-changesets/test/contract/fixtures/marcusrbrown-infra/repo/apps/cliproxy/docker-compose.yaml
+++ b/.github/actions/renovate-changesets/test/contract/fixtures/marcusrbrown-infra/repo/apps/cliproxy/docker-compose.yaml
@@ -1,0 +1,3 @@
+services:
+  cliproxy:
+    image: eceasy/cli-proxy-api:v7.2.134@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef

--- a/.github/actions/renovate-changesets/test/contract/fixtures/marcusrbrown-infra/repo/apps/cliproxy/package.json
+++ b/.github/actions/renovate-changesets/test/contract/fixtures/marcusrbrown-infra/repo/apps/cliproxy/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@marcusrbrown/infra-cliproxy",
+  "private": true,
+  "dependencies": {
+    "@marcusrbrown/infra-shared": "workspace:*"
+  }
+}

--- a/.github/actions/renovate-changesets/test/contract/fixtures/marcusrbrown-infra/repo/apps/gateway/Dockerfile
+++ b/.github/actions/renovate-changesets/test/contract/fixtures/marcusrbrown-infra/repo/apps/gateway/Dockerfile
@@ -1,0 +1,1 @@
+FROM eceasy/cli-proxy-api:v7.2.134@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef

--- a/.github/actions/renovate-changesets/test/contract/fixtures/marcusrbrown-infra/repo/apps/gateway/package.json
+++ b/.github/actions/renovate-changesets/test/contract/fixtures/marcusrbrown-infra/repo/apps/gateway/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@marcusrbrown/infra-gateway",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@marcusrbrown/infra-shared": "workspace:*"
+  }
+}

--- a/.github/actions/renovate-changesets/test/contract/fixtures/marcusrbrown-infra/repo/apps/vpn/Dockerfile
+++ b/.github/actions/renovate-changesets/test/contract/fixtures/marcusrbrown-infra/repo/apps/vpn/Dockerfile
@@ -1,0 +1,1 @@
+FROM alpine:3.22

--- a/.github/actions/renovate-changesets/test/contract/fixtures/marcusrbrown-infra/repo/apps/vpn/package.json
+++ b/.github/actions/renovate-changesets/test/contract/fixtures/marcusrbrown-infra/repo/apps/vpn/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@marcusrbrown/infra-vpn",
+  "private": true,
+  "dependencies": {
+    "@marcusrbrown/infra-shared": "workspace:*"
+  }
+}

--- a/.github/actions/renovate-changesets/test/contract/fixtures/marcusrbrown-infra/repo/package.json
+++ b/.github/actions/renovate-changesets/test/contract/fixtures/marcusrbrown-infra/repo/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@marcusrbrown/infra-workspace",
+  "private": true,
+  "type": "module",
+  "workspaces": [
+    "apps/*",
+    "packages/*"
+  ],
+  "prettier": "@bfra.me/prettier-config/120-proof"
+}

--- a/.github/actions/renovate-changesets/test/contract/fixtures/marcusrbrown-infra/repo/packages/cli/package.json
+++ b/.github/actions/renovate-changesets/test/contract/fixtures/marcusrbrown-infra/repo/packages/cli/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@marcusrbrown/infra",
+  "version": "0.15.4"
+}

--- a/.github/actions/renovate-changesets/test/contract/fixtures/marcusrbrown-infra/repo/packages/shared/package.json
+++ b/.github/actions/renovate-changesets/test/contract/fixtures/marcusrbrown-infra/repo/packages/shared/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@marcusrbrown/infra-shared",
+  "version": "0.0.0",
+  "private": true
+}

--- a/.github/actions/renovate-changesets/test/contract/setup.ts
+++ b/.github/actions/renovate-changesets/test/contract/setup.ts
@@ -76,10 +76,6 @@ export function getOctokitMocks(): typeof octokitMocks {
   return octokitMocks
 }
 
-export function getExecMocks(): typeof execMocks {
-  return execMocks
-}
-
 beforeEach(() => {
   contractState.previousEnv = {...process.env}
   contractState.inputs = {}
@@ -93,7 +89,16 @@ beforeEach(() => {
 
   octokitMocks.listFiles.mockResolvedValue({data: []})
   octokitMocks.listCommits.mockResolvedValue({data: []})
-  execMocks.getExecOutput.mockResolvedValue({stdout: 'contract1\n', stderr: '', exitCode: 0})
+  // Contract invariant: every getExecOutput call reaching this mock must be the
+  // git rev-parse --short HEAD lookup. The feature gates above keep all other
+  // git-operations.ts calls out of this suite; if one is enabled, fail loudly.
+  execMocks.getExecOutput.mockImplementation(async (command: string, args: string[]) => {
+    if (command !== 'git' || args.length !== 3 || args.join(' ') !== 'rev-parse --short HEAD') {
+      throw new Error(`Unexpected contract getExecOutput command: ${command} ${args.join(' ')}`)
+    }
+
+    return {stdout: 'contract1\n', stderr: '', exitCode: 0}
+  })
 })
 
 afterEach(() => {

--- a/.github/actions/renovate-changesets/test/contract/setup.ts
+++ b/.github/actions/renovate-changesets/test/contract/setup.ts
@@ -1,0 +1,102 @@
+import process from 'node:process'
+import {afterEach, beforeEach, vi} from 'vitest'
+
+type MockFn = ReturnType<typeof vi.fn>
+
+interface ContractState {
+  inputs: Record<string, string>
+  booleanInputs: Record<string, boolean>
+  outputs: Map<string, string>
+  info: string[]
+  warnings: string[]
+  errors: string[]
+  debug: string[]
+  failed: string[]
+  previousEnv: NodeJS.ProcessEnv
+}
+
+interface OctokitMocks {
+  listFiles: MockFn
+  listCommits: MockFn
+}
+
+interface ExecMocks {
+  getExecOutput: MockFn
+}
+
+const contractState = vi.hoisted<ContractState>(() => ({
+  inputs: {},
+  booleanInputs: {},
+  outputs: new Map(),
+  info: [],
+  warnings: [],
+  errors: [],
+  debug: [],
+  failed: [],
+  previousEnv: {},
+}))
+
+const octokitMocks = vi.hoisted<OctokitMocks>(() => ({
+  listFiles: vi.fn(),
+  listCommits: vi.fn(),
+}))
+
+const execMocks = vi.hoisted<ExecMocks>(() => ({
+  getExecOutput: vi.fn(),
+}))
+
+vi.mock('@actions/core', () => ({
+  getInput: vi.fn((name: string) => contractState.inputs[name] ?? ''),
+  getBooleanInput: vi.fn((name: string) => contractState.booleanInputs[name] ?? false),
+  info: vi.fn((message: string) => contractState.info.push(message)),
+  warning: vi.fn((message: string) => contractState.warnings.push(message)),
+  error: vi.fn((message: string) => contractState.errors.push(message)),
+  debug: vi.fn((message: string) => contractState.debug.push(message)),
+  setFailed: vi.fn((message: string) => contractState.failed.push(message)),
+  setOutput: vi.fn((name: string, value: unknown) => {
+    contractState.outputs.set(name, String(value))
+  }),
+}))
+
+vi.mock('@octokit/rest', () => ({
+  Octokit: class {
+    readonly rest = {pulls: octokitMocks}
+  },
+}))
+
+vi.mock('@actions/exec', () => ({
+  getExecOutput: execMocks.getExecOutput,
+}))
+
+export function getContractState(): ContractState {
+  return contractState
+}
+
+export function getOctokitMocks(): typeof octokitMocks {
+  return octokitMocks
+}
+
+export function getExecMocks(): typeof execMocks {
+  return execMocks
+}
+
+beforeEach(() => {
+  contractState.previousEnv = {...process.env}
+  contractState.inputs = {}
+  contractState.booleanInputs = {}
+  contractState.outputs.clear()
+  contractState.info.length = 0
+  contractState.warnings.length = 0
+  contractState.errors.length = 0
+  contractState.debug.length = 0
+  contractState.failed.length = 0
+
+  octokitMocks.listFiles.mockResolvedValue({data: []})
+  octokitMocks.listCommits.mockResolvedValue({data: []})
+  execMocks.getExecOutput.mockResolvedValue({stdout: 'contract1\n', stderr: '', exitCode: 0})
+})
+
+afterEach(() => {
+  for (const key of Object.keys(process.env)) delete process.env[key]
+  Object.assign(process.env, contractState.previousEnv)
+})

--- a/.github/actions/renovate-changesets/vitest.config.ts
+++ b/.github/actions/renovate-changesets/vitest.config.ts
@@ -1,4 +1,4 @@
-import {defineConfig} from 'vitest/config'
+import {configDefaults, defineConfig} from 'vitest/config'
 
 export default defineConfig({
   test: {
@@ -18,5 +18,6 @@ export default defineConfig({
       },
     },
     setupFiles: ['./test/setup.ts'],
+    exclude: [...configDefaults.exclude, 'test/contract/**'],
   },
 })

--- a/.github/actions/renovate-changesets/vitest.contract.config.ts
+++ b/.github/actions/renovate-changesets/vitest.contract.config.ts
@@ -1,0 +1,16 @@
+import {fileURLToPath} from 'node:url'
+import {defineProject} from 'vitest/config'
+
+export default defineProject({
+  root: fileURLToPath(new URL('.', import.meta.url)),
+  test: {
+    name: 'renovate-changesets-contract',
+    environment: 'node',
+    globals: true,
+    include: ['test/contract/**/*.contract.test.ts'],
+    setupFiles: ['./test/contract/setup.ts'],
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
+    fileParallelism: false,
+  },
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,9 @@ export default defineConfig({
       reporter: ['text', 'json', 'html'],
       include: ['src/**/*.ts'],
     },
-    projects: ['.github/actions/*'],
+    projects: [
+      '.github/actions/*',
+      '.github/actions/renovate-changesets/vitest.contract.config.ts',
+    ],
   },
 })


### PR DESCRIPTION
This action runs inside consumer repositories but has only ever been tested inside this one. Five production bugs escaped that way in quick succession — self-hosted bot identity, Docker short SHAs, a writer with no fallback, impact misclassification, and most recently a changeset that Changesets itself refuses to accept. Every one of them was invisible to the test suite, because every fixture was written by the same person holding the assumption that broke.

More tests would not have caught these. The suite's `end-to-end` test mocks the filesystem, mocks `@changesets/write`, and mocks workspace analysis. `run-on-disk.test.ts` does not touch disk — it imports `mockedFileSystem`. What was missing is an executable consumer contract whose final judge is Changesets itself.

## What this adds

A separate Vitest project, `renovate-changesets-contract`, that runs the action end to end against a real temporary workspace on a real filesystem, then validates the result with the real Changesets CLI.

A separate project is not stylistic. `test/setup.ts` installs `vi.mock('node:fs/promises')` and `vi.mock('@changesets/write')` through `setupFiles`, so no individual test file in the existing project can opt out.

Exactly three boundaries are stubbed: `@octokit/rest` (only `pulls.listFiles` and `pulls.listCommits`), `@actions/core`, and the single `git rev-parse --short HEAD` call. Nothing else. Real filesystem, real writer, real Changesets.

The fixture mirrors `marcusrbrown/infra` and is deliberately hostile:

- no `node_modules`, asserted after copy
- a root `prettier` field pointing at `@bfra.me/prettier-config/120-proof`, which cannot resolve
- `apps/cliproxy` and `apps/vpn` with no `version` field
- `@marcusrbrown/infra-vpn` in the Changesets `ignore` list
- `NODE_ENV=production` with `VITEST` unset, so `isTestEnvironment()` cannot short-circuit the writer path that broke in production

The oracle runs `changeset status` against the generated output and parses the release plan. Not `changeset version` — that mutates manifests and needs a changelog package the fixture deliberately lacks. `status` performs the same release-plan assembly, which is where mixed ignored/not-ignored changesets are rejected.

## Verification

One scenario, `docker-short-sha`, green against unmodified production code. It pins self-hosted bot provenance, real Renovate table parsing, Docker manager detection, and the `@changesets/write` fallback firing under an unresolvable consumer Prettier config.

That last one is not theoretical here — the run emits the real warning:

```
@changesets/write failed, falling back to manual creation:
Cannot find module '@bfra.me/prettier-config/120-proof'
```

To confirm the harness is not passing vacuously, I pointed the same scenario at the versionless `apps/cliproxy` package. It reproduced the production failure exactly:

```
Found mixed changeset renovate-group--marcusrbrown-infra-cliproxy--marcusrbrown-infra-s
Found ignored packages: @marcusrbrown/infra-cliproxy
Found not ignored packages: @marcusrbrown/infra-shared
Mixed changesets that contain both ignored and not ignored packages are not allowed
```

Same filename, same error, same CLI. That scenario is held back for the follow-up PR that fixes the underlying bug, so this one stays green.

Run it with `pnpm test --project renovate-changesets-contract`. Existing tests are unchanged at 513.

Test infrastructure only. No source changes, no `dist` rebuild, no changeset.