### PR TITLE
test(renovate-changesets): cover lockfile attribution

### DIFF
--- a/.github/actions/renovate-changesets/test/contract/fixtures/bfra-github/.github/actions/renovate-changesets/package.json
+++ b/.github/actions/renovate-changesets/test/contract/fixtures/bfra-github/.github/actions/renovate-changesets/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "renovate-changesets",
+  "version": "0.2.41",
+  "private": true
+}

--- a/.github/actions/renovate-changesets/test/contract/fixtures/bfra-github/.github/actions/update-metadata/package.json
+++ b/.github/actions/renovate-changesets/test/contract/fixtures/bfra-github/.github/actions/update-metadata/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "update-metadata",
+  "version": "0.1.14",
+  "private": true
+}

--- a/.github/actions/renovate-changesets/test/contract/fixtures/bfra-github/.github/actions/update-repository-settings/package.json
+++ b/.github/actions/renovate-changesets/test/contract/fixtures/bfra-github/.github/actions/update-repository-settings/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "update-repository-settings",
+  "version": "0.1.8",
+  "private": true
+}

--- a/.github/actions/renovate-changesets/test/contract/lockfile-maintenance.contract.test.ts
+++ b/.github/actions/renovate-changesets/test/contract/lockfile-maintenance.contract.test.ts
@@ -9,6 +9,9 @@ import {run} from '../../src/run.js'
 import {authoredReleases, effectiveReleases, runChangesetsOracle} from './changesets-oracle.js'
 import {getContractState, getOctokitMocks} from './setup.js'
 
+// Package versions in this fixture are a deliberate snapshot of the repository as PR #2585 saw
+// it, not a mirror of current versions. Attribution matches on package name, so they never need
+// bumping after a release.
 const fixtureRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   'fixtures/bfra-github',

--- a/.github/actions/renovate-changesets/test/contract/lockfile-maintenance.contract.test.ts
+++ b/.github/actions/renovate-changesets/test/contract/lockfile-maintenance.contract.test.ts
@@ -145,7 +145,7 @@ describe('lockfile maintenance contract', () => {
     workspace = ''
   })
 
-  it('creates a patch changeset for pnpm lockfile maintenance', async () => {
+  it('attributes lockfile maintenance to every changed workspace package', async () => {
     await run()
 
     expect(contractState.failed).toEqual([])
@@ -156,6 +156,71 @@ describe('lockfile maintenance contract', () => {
     expect(JSON.parse(contractState.outputs.get('dependencies') ?? 'null')).toEqual([])
 
     const oracle = await runChangesetsOracle('lockfile-maintenance', workspace, {
+      errors: contractState.errors,
+      warnings: contractState.warnings,
+      outputs: contractState.outputs,
+    })
+    expect(authoredReleases(oracle.releasePlan).map(({name, type}) => ({name, type}))).toEqual([
+      {name: '@bfra.me/.github', type: 'patch'},
+      {name: 'renovate-changesets', type: 'patch'},
+      {name: 'update-metadata', type: 'patch'},
+      {name: 'update-repository-settings', type: 'patch'},
+    ])
+    expect(effectiveReleases(oracle.releasePlan).map(({name, type}) => ({name, type}))).toEqual([
+      {name: '@bfra.me/.github', type: 'patch'},
+      {name: 'renovate-changesets', type: 'patch'},
+      {name: 'update-metadata', type: 'patch'},
+      {name: 'update-repository-settings', type: 'patch'},
+    ])
+    const summaries = oracle.releasePlan.changesets.map(changeset => changeset.summary)
+    expect(summaries).toHaveLength(4)
+    expect(summaries.every(summary => summary.includes('Refresh pnpm lockfile dependencies'))).toBe(
+      true,
+    )
+  })
+
+  it('deduplicates a package with an existing pending changeset', async () => {
+    await fs.writeFile(
+      path.join(workspace, '.changeset/existing-renovate-changesets.md'),
+      `---\n'renovate-changesets': patch\n---\n\nExisting pending work.\n`,
+      'utf8',
+    )
+
+    await run()
+
+    expect(contractState.outputs.get('changesets-created')).toBe('3')
+    expect(JSON.parse(contractState.outputs.get('changeset-files') ?? 'null')).toHaveLength(3)
+
+    // Remove the seeded file before invoking the oracle: Changesets status reports every file in
+    // .changeset, while the action's changeset-files output identifies what this run authored.
+    await fs.rm(path.join(workspace, '.changeset/existing-renovate-changesets.md'))
+
+    const oracle = await runChangesetsOracle('lockfile-maintenance-existing', workspace, {
+      errors: contractState.errors,
+      warnings: contractState.warnings,
+      outputs: contractState.outputs,
+    })
+    expect(authoredReleases(oracle.releasePlan).map(({name, type}) => ({name, type}))).toEqual([
+      {name: '@bfra.me/.github', type: 'patch'},
+      {name: 'update-metadata', type: 'patch'},
+      {name: 'update-repository-settings', type: 'patch'},
+    ])
+    expect(effectiveReleases(oracle.releasePlan).map(({name, type}) => ({name, type}))).toEqual([
+      {name: '@bfra.me/.github', type: 'patch'},
+      {name: 'update-metadata', type: 'patch'},
+      {name: 'update-repository-settings', type: 'patch'},
+    ])
+    expect(oracle.releasePlan.changesets).toHaveLength(3)
+  })
+
+  it('uses the root fallback when only the lockfile changes', async () => {
+    octokitMocks.listFiles.mockResolvedValue({
+      data: [{filename: 'pnpm-lock.yaml', status: 'modified', additions: 1, deletions: 1}],
+    })
+
+    await run()
+
+    const oracle = await runChangesetsOracle('lockfile-maintenance-fallback', workspace, {
       errors: contractState.errors,
       warnings: contractState.warnings,
       outputs: contractState.outputs,


### PR DESCRIPTION
The lockfile-maintenance contract scenario asserted one authored changeset. The real pull request it was modelled on produced three.

The fixture declared `workspaces: [".", ".github/actions/*"]` but contained no action packages on disk, so glob expansion found nothing, no directly-affected package was releasable, and the fallback wrote a single root changeset. The scenario proved the body parsed. It never touched attribution.

That is the same fixture weakness that let earlier release-set expectations pass while being wrong: a scenario that exercises the path you were thinking about and quietly skips the one you weren't.

## Three, four, and why the difference matters

Adding the three action manifests and PR #2585's real changed-file set produces **four** authored changesets, not three.

The missing one is `renovate-changesets`, and it is missing for a reason that has nothing to do with attribution. At the commit that pull request ran against, `.changeset/` already held four pending changesets and every one of them targeted `'renovate-changesets': patch`. The action found four affected packages and skipped authoring a fifth for a package that already had pending changesets with the same release set.

So production's three was four minus a deduplication. Four is the correct result for a clean workspace, and asserting three would have encoded that day's changeset backlog into the contract.

## What is now covered

Three scenarios:

- **attribution** — the real four-file set on a clean workspace authors all four packages, each summarised `Refresh pnpm lockfile dependencies`
- **deduplication** — the same input with a pending `renovate-changesets` changeset seeded authors only the other three
- **fallback** — only `pnpm-lock.yaml` changed, so no package is directly affected and the root changeset is written

The deduplication scenario matters more than its size suggests. This repository's `.changeset/` normally holds seven to eighteen pending changesets between releases and is essentially never empty, so that path runs constantly in production and had no coverage at all. Removing the seed drops the run from three authored files to four, which is the evidence it asserts the rule rather than passing incidentally.

## One thing worth knowing

The deduplication in `existing-changeset-analyzer.ts` scans every `.changeset/*.md` on disk, excluding only `README*`. It is not scoped to changesets the current pull request added.

Since the directory is never empty here, a changeset from unrelated earlier work can suppress authoring for that package — which is precisely what happened in #2585. `duplicate-strategies.ts` compares release sets exactly, so suppression only occurs on an exact match, which narrows this considerably.

Whether that is correct by design is a genuine question, and it is not answered here. This pull request pins the current behaviour so any future change to it is deliberate and visible.

No source changes, no `dist` rebuild, no changeset. 572 unit tests and 24 contract tests.