### PR TITLE
docs(solutions): capture renovate-changesets consumer-parity learnings

### DIFF
--- a/docs/solutions/best-practices/contract-testing-actions-that-run-in-foreign-repos-2026-08-19.md
+++ b/docs/solutions/best-practices/contract-testing-actions-that-run-in-foreign-repos-2026-08-19.md
@@ -1,0 +1,153 @@
+---
+title: Contract-first testing for actions that run in foreign repos
+date: 2026-08-19
+category: best-practices
+module: .github/actions/renovate-changesets
+problem_type: best_practice
+component: testing_framework
+severity: high
+applies_when:
+  - An action is developed in one repo but executes in others
+  - Local CI passes while the consumer repo breaks
+  - A refactor is scoped by what can be deleted rather than by the runtime contract
+related_components:
+  - tooling
+  - development_workflow
+tags:
+  - contract-testing
+  - renovate-changesets
+  - changesets
+  - consumer-repo
+  - test-strategy
+---
+
+## Context
+
+`renovate-changesets` is developed in `.github/actions/renovate-changesets/` but executes inside consumer repositories. Its real contract is much larger than this repository's build: consumer bot identity, Renovate PR body dialect, workspace topology, dependency-install state, and `.changeset/config.json`.
+
+A prior slimming refactor was scoped by local reachability — it mapped what could be deleted here, never modeling the environment the action actually runs in. It _required_ correct output in `marcusrbrown/infra` but gated release on local `type-check → test → lint → build`. "Works in the consumer" was an aspiration, never a gate.
+
+Six false assumptions followed, each true here and false there:
+
+- Renovate always runs as `renovate[bot]` — consumers also use `bfra-me[bot]` and `mrbro-bot[bot]`
+- Docker references always carry full digests — consumers supply short SHAs
+- `@changesets/write` succeeds because dependencies are installed — consumer workspaces have no `node_modules` at that point
+- An affected package is always listed in a manifest
+- Every workspace package is releasable
+- One grouped Renovate PR has one package manager
+
+The contract suite makes those assumptions executable. It is 12 files and 25 tests under `test/contract/`: ten `*.contract.test.ts` scenarios plus `setup.ts` and `changesets-oracle.ts`.
+
+## Guidance
+
+**Enter through the real `run()`** in `src/run.ts`. Not `index.ts` — that invokes `run` as an import side effect, so merely importing it would execute the action.
+
+**Use a real temporary workspace.** Each scenario copies a fixture with `fs.cp(..., {recursive: true})`. The fixture at `test/contract/fixtures/marcusrbrown-infra/repo/` is deliberately hostile:
+
+- declares `apps/*`, `packages/*`, and `libs/*` workspaces with an unresolvable prettier config
+- `apps/cliproxy` and `apps/vpn` are versionless
+- `.changeset/config.json` ignores `@marcusrbrown/infra-vpn`, enables private-package versioning, and sets `updateInternalDependencies`
+- `packages/shared` carries real dependencies, so the suite can test propagation as well as exclusion
+
+**Keep the boundary narrow.** Only `@actions/core`, `@octokit/rest`, and a single exec lookup are stubbed. In `test/contract/setup.ts`, `getExecOutput` accepts exactly `git rev-parse --short HEAD` and throws on anything else:
+
+```ts
+execMocks.getExecOutput.mockImplementation(async (command, args) => {
+  if (command !== 'git' || args.join(' ') !== 'rev-parse --short HEAD') {
+    throw new Error(`Unexpected contract getExecOutput command: ${command} ${args.join(' ')}`)
+  }
+  return {stdout: 'contract1\n', stderr: '', exitCode: 0}
+})
+```
+
+That is deliberate. Enabling a new git dependency without updating the contract is drift, and it should fail loudly.
+
+**Use the real Changesets CLI as the final oracle.** `test/contract/changesets-oracle.ts` runs the repository's installed `@changesets/cli`:
+
+```text
+changeset status --output .contract-release-plan.json
+```
+
+It exposes two views, and they answer different questions:
+
+- `authoredReleases()` — `releasePlan.changesets.flatMap(c => c.releases)`, what the action wrote
+- `effectiveReleases()` — the final plan after `updateInternalDependencies`, excluding `type: "none"`
+
+**A separate Vitest project is mandatory.** `vitest.contract.config.ts` defines `renovate-changesets-contract` and loads `test/contract/setup.ts`. The normal `test/setup.ts` globally mocks `node:fs`, `node:fs/promises`, and `@changesets/write` with no per-file opt-out — the separate project is what restores real filesystem behavior and real Changesets execution.
+
+**Assert captured output, never rejection.** `run()` catches failures into `core.setFailed`, so successful error handling resolves normally. `await expect(run()).rejects.toThrow(...)` will never fire.
+
+**Requirements:** `git` on `PATH`, and a completed root `pnpm install` since the oracle resolves `node_modules/@changesets/cli/bin.js`.
+
+```bash
+pnpm test --project renovate-changesets-contract
+```
+
+**Prove every fix RED first.** Revert `src/`, run the suite, confirm that _only_ the intended scenarios fail. This is not ceremony — a tag-to-digest `pinDigest` case once stayed green by coincidence while the bare-SHA case was genuinely red. A green test is evidence only after its failure mode has been demonstrated.
+
+## Why This Matters
+
+Local tests prove behavior under local conditions. They do not prove an action survives the environment a foreign repository hands it.
+
+The scenarios map directly onto the failures that reached production:
+
+| Scenario               | Boundary                                                   |
+| ---------------------- | ---------------------------------------------------------- |
+| `unknown-bot-identity` | bot recognition outside `renovate[bot]`                    |
+| `docker-short-sha`     | digest parsing with a short SHA                            |
+| `writer-failure`       | write failure reported when consumer deps are absent       |
+| `releasable-packages`  | versioned / versionless / ignored / glob packages          |
+| `mixed-npm-actions`    | per-row package-manager identity                           |
+| `provider-update`      | action authors the provider; Changesets adds the dependent |
+| `control-plane-prs`    | config-migration and onboarding PRs                        |
+
+Without these, the release gate validates the implementation's home environment instead of the action's execution contract.
+
+## When to Apply
+
+Add or update a contract scenario when a change touches:
+
+- Renovate bot recognition, branch detection, PR-body parsing, or grouped updates
+- Docker, git, lockfile, or filesystem handling
+- Workspace discovery, package eligibility, dependency propagation, or Changesets configuration
+- Any code assuming installed dependencies in `GITHUB_WORKSPACE`
+- Any output consumed by a release workflow or downstream repository
+
+Do not swap a contract test for a unit test because the unit test is faster. Use both — unit tests for local rules, contract tests for the foreign-repository boundary.
+
+## Examples
+
+Construct consumer state, run the real entry point, then invoke the real oracle:
+
+```ts
+await fs.cp(fixtureRoot, workspace, {recursive: true})
+initializeGitRepository(workspace)
+
+process.env.GITHUB_WORKSPACE = workspace
+process.env.GITHUB_REPOSITORY = 'marcusrbrown/infra'
+
+await run()
+
+expect(contractState.failed).toEqual([])
+
+const oracle = await runChangesetsOracle('provider-update', workspace, diagnostics)
+
+expect(authoredReleases(oracle.releasePlan).map(({name}) => name)).toEqual([
+  '@marcusrbrown/infra-shared',
+])
+
+expect(effectiveReleases(oracle.releasePlan).map(({name}) => name)).toEqual([
+  '@marcusrbrown/infra-shared',
+  '@marcusrbrown/infra-gateway',
+])
+```
+
+Name the layer each assertion verifies. `effectiveReleases` alone cannot detect over-authoring, because Changesets expands the plan either way.
+
+## Related
+
+- [Test fixtures underspecified in the dimension the code ignores](./test-fixtures-underspecified-in-ignored-dimension-2026-08-19.md)
+- [Release propagation walked the dependency graph backwards](../logic-errors/release-propagation-walked-dependency-graph-backwards-2026-08-19.md)
+- [Changeset deduplication compared release sets but not summaries](../logic-errors/changeset-dedup-ignored-summaries-2026-08-19.md)
+- [renovate-changesets fix workflow](../process/renovate-changesets-fix-workflow.md)
+- [Renovate SHA pin rot across two tag families](../integration-issues/renovate-sha-pin-rot-two-tag-families-2026-08-15.md)

--- a/docs/solutions/best-practices/test-fixtures-underspecified-in-ignored-dimension-2026-08-19.md
+++ b/docs/solutions/best-practices/test-fixtures-underspecified-in-ignored-dimension-2026-08-19.md
@@ -1,0 +1,150 @@
+---
+title: Test fixtures underspecified in the dimension the code ignores
+date: 2026-08-19
+category: best-practices
+module: .github/actions/renovate-changesets
+problem_type: best_practice
+component: testing_framework
+severity: high
+applies_when:
+  - A comparator, parser, classifier, or planner gains a new field
+  - A previously ignored field becomes part of equality, hashing, or filtering
+  - A fixture uses empty strings, empty arrays, or omitted properties
+  - A test asserts derived output instead of authored input
+related_components:
+  - tooling
+tags:
+  - test-fixtures
+  - test-strategy
+  - renovate-changesets
+  - changesets
+  - dependency-graph
+---
+
+## Context
+
+A fixture is executable specification. If it is vague in exactly the dimension the code currently ignores, it becomes load-bearing the moment the code starts caring — and until then, the test can encode the bug it claims to prevent.
+
+This happened four times in `renovate-changesets`, and each instance passed review:
+
+1. Contract scenarios asserted only Changesets' **final** release plan, never what the action authored
+2. The contract fixture's `packages/shared` declared **zero** dependencies
+3. A multi-package relationship fixture had the dependency direction **reversed**
+4. A duplicate-detection fixture omitted the **summary** that later became part of comparison
+
+A related failure: a tautological assertion, `expect(info).not.toHaveBeenCalledWith(expect.stringContaining('duplicate'))`, verified that the implementation never logged text it was never written to log. It could not fail.
+
+## Guidance
+
+**Specify every fixture field that participates in the behavior under test, even if the implementation ignores it today.**
+
+### Identify the assertion target
+
+In Changesets, the final plan is not the authored input. `test/contract/changesets-oracle.ts` exposes both:
+
+- `authoredReleases()` — releases explicitly written into generated changesets
+- `effectiveReleases()` — the final plan after `updateInternalDependencies` and `type: "none"` filtering
+
+Most scenarios have identical authored and effective sets. Exactly one diverges — `test/contract/provider-update.contract.test.ts`, where `@marcusrbrown/infra-shared` is authored while `@marcusrbrown/infra-gateway` appears only in the effective plan. That single scenario carries the entire guarantee. Do not delete it or collapse the two assertions.
+
+### Build fixtures with both graph directions
+
+`packages/shared` now declares real dependencies while `apps/gateway` consumes `@marcusrbrown/infra-shared`. That edge lets the suite detect **under**-release. A fixture with no dependencies can only ever prove exclusion — it cannot prove that something which should release does.
+
+### Read relationships in the direction the data structure uses
+
+`relationship(source, target)` means the source _declares_ a dependency on the target. So `a → b` means A consumes B, and B cannot become indirectly affected by A. Direct and indirect lists must follow the graph, not an intuitive "change flows forward" reading.
+
+### Populate every field the comparison reads
+
+Once the duplicate comparator considers summary content, an existing changeset fixture needs a meaningful `summary` — not `''`. An empty field is not neutral once the comparator reads it; it asserts the defect.
+
+### Assert observable state
+
+Assert returned duplicate sets, filenames, release entries, generated files, warnings, failures. A negative log assertion is valid only when production code actually emits the forbidden log and the test creates the condition that should suppress it.
+
+## Why This Matters
+
+Underspecified fixtures create false confidence, and the failure is silent.
+
+The original contract assertions read `releasePlan.releases`. Changesets adds dependent packages during plan assembly, so an over-broad authored set and a correctly expanded one produce the **same** final plan. Three wrong expectations passed review three separate times because the assertion erased the distinction that mattered.
+
+The dependency-free `packages/shared` fixture had the same shape problem in a different dimension: it could demonstrate that a package should not be released, never that one should.
+
+The reversed `a → b` relationship described an impossible impact direction. The test passed while teaching future changes the wrong dependency vocabulary.
+
+The empty duplicate summary passed while summary comparison was effectively disabled. When summary became load-bearing, that fixture asserted the bug rather than guarding against it.
+
+A tautological assertion is worse than no assertion — it consumes review attention while providing no failure signal.
+
+## When to Apply
+
+Audit fixture completeness when:
+
+- A comparator, parser, classifier, or planner gains a new field
+- A test moves from unit-level return values to final assembled output
+- A graph, workspace, or dependency relationship is involved
+- A previously ignored field enters hashing, equality, deduplication, or filtering
+- A negative assertion is added
+- A fixture uses empty strings, empty arrays, omitted properties, or placeholders
+
+Before merging, run the test against the intended defect. **If reverting the production change leaves the test green, the fixture or the assertion is wrong.**
+
+## Examples
+
+Distinguish authored input from derived output:
+
+```ts
+expect(authoredReleases(oracle.releasePlan).map(({name}) => name)).toEqual([
+  '@marcusrbrown/infra-shared',
+])
+
+expect(effectiveReleases(oracle.releasePlan).map(({name}) => name)).toEqual([
+  '@marcusrbrown/infra-shared',
+  '@marcusrbrown/infra-gateway',
+])
+```
+
+Give a fixture enough graph structure to test propagation:
+
+```json
+{
+  "name": "@marcusrbrown/infra-gateway",
+  "version": "0.0.0",
+  "dependencies": {
+    "@marcusrbrown/infra-shared": "workspace:*"
+  }
+}
+```
+
+Populate fields the comparison reads:
+
+```ts
+const existing = {
+  filename: 'existing.md',
+  content: '---\n"pkg-a": patch\n---\nUpdate dep',
+  releases: [{name: 'pkg-a', type: 'patch' as const}],
+  summary: 'Update dep',
+  createdAt: new Date(),
+  age: 0,
+}
+
+expect(isChangesetDuplicateOfExisting(candidate, existing)).toBe(true)
+```
+
+### Checklist for any new fixture dimension
+
+1. Can the test fail if this field is wrong?
+2. Does the fixture contain both sides of the comparison?
+3. Does the assertion observe authored, derived, or side-effect state explicitly?
+4. Does the relationship direction match source/target semantics?
+5. If the implementation ignores this field today, will the fixture stay truthful when it starts reading it?
+6. Can the test pass without the expected production behavior?
+
+If the answer to the last one is yes, it is a dressed-up tautology.
+
+## Related
+
+- [Contract-first testing for actions that run in foreign repos](./contract-testing-actions-that-run-in-foreign-repos-2026-08-19.md)
+- [Release propagation walked the dependency graph backwards](../logic-errors/release-propagation-walked-dependency-graph-backwards-2026-08-19.md)
+- [Changeset deduplication compared release sets but not summaries](../logic-errors/changeset-dedup-ignored-summaries-2026-08-19.md)

--- a/docs/solutions/logic-errors/changeset-dedup-ignored-summaries-2026-08-19.md
+++ b/docs/solutions/logic-errors/changeset-dedup-ignored-summaries-2026-08-19.md
@@ -1,0 +1,114 @@
+---
+title: Changeset deduplication compared release sets but not summaries
+date: 2026-08-19
+category: logic-errors
+module: .github/actions/renovate-changesets
+problem_type: logic_error
+component: tooling
+symptoms:
+  - Generated changeset silently skipped as a duplicate
+  - Lockfile-maintenance entry missing from the changelog
+  - Unrelated pending changeset for the same package and bump type suppressed a real one
+root_cause: logic_error
+resolution_type: code_fix
+severity: high
+related_components:
+  - development_workflow
+tags:
+  - renovate-changesets
+  - changesets
+  - deduplication
+  - release-automation
+  - idempotency
+---
+
+## Problem
+
+`isChangesetDuplicateOfExisting` compared only release entries — package name plus bump type (`src/deduplicator/changeset-comparator.ts:65-79`). The summary was never read.
+
+That is unsafe because `analyzeExistingChangesets` scans **every** recent `.changeset/*.md` on disk, excluding only `README*` and entries older than `maxExistingChangesetAge` (`src/deduplicator/existing-changeset-analyzer.ts:14-34`). It does not know which files the current PR added.
+
+Any pending `pkg: patch` changeset could therefore suppress a genuinely different change for the same package. This repository normally carries 7–18 pending changesets between releases, so the collision surface is large.
+
+## Symptoms
+
+The action generated a valid changeset, then skipped it because an existing changeset shared its release set — even when the summaries described unrelated work.
+
+The old comparison could not distinguish:
+
+```md
+---
+'renovate-changesets': patch
+---
+
+Refresh pnpm lockfile dependencies
+```
+
+from:
+
+```md
+---
+'renovate-changesets': patch
+---
+
+Unrelated package maintenance
+```
+
+In production, a lockfile-maintenance PR lost its entry: four unrelated pending `renovate-changesets: patch` changesets from earlier work swallowed it, and the change never reached the changelog.
+
+## What Didn't Work
+
+**Comparing release sets alone.** Package and bump type identify the release _target_, not the change being released. Two unrelated updates to the same package at the same bump level are indistinguishable under that rule.
+
+**Scoping the scan to PR-added files** would address the collision at its root — but that is not what this fix does. `analyzeExistingChangesets` still scans the directory, subject only to the README and age filters. The fix narrows the match without pretending to solve scoping.
+
+## Solution
+
+`isChangesetDuplicateOfExisting` now requires **both** an equal normalized release set and an equal normalized summary:
+
+```ts
+return (
+  newReleases.every((release, index) => release === existingReleases[index]) &&
+  normalizeSummary(changeset.summary) === normalizeSummary(existing.summary)
+)
+```
+
+Normalization is deliberately small and deterministic:
+
+```ts
+function normalizeSummary(summary: string): string {
+  return summary.trim().replaceAll(/\s+/gu, ' ')
+}
+```
+
+Trim, collapse internal whitespace. Case-sensitive, no fuzzy matching (`changeset-comparator.ts:82-84`).
+
+`calculateChangesetContentHash` uses the same helper rather than duplicating the logic inline — two copies ten lines apart would have drifted the first time either was touched.
+
+## Why This Works
+
+The deduplication mechanism exists for idempotency: Renovate force-pushes constantly and the action re-runs on the same PR. A re-run produces the same release set **and** the same generated summary, so an identical pending changeset still suppresses duplicate work.
+
+A genuinely different summary no longer collides merely because it targets the same package at the same bump level.
+
+The summary includes the generated multi-package footer:
+
+```md
+**Multi-package update** for package `renovate-changesets`.
+```
+
+So re-run idempotency now depends on the complete generated summary being **byte-deterministic, footer included**. If that footer's wording, punctuation, package interpolation, or ordering ever varies between runs, summary equality fails and duplicate suppression silently stops working.
+
+## Prevention
+
+- Compare release sets **and** normalized summaries for exact duplicate detection
+- Keep normalization centralized in `normalizeSummary`; `calculateChangesetContentHash` must keep using it
+- Preserve both contract scenarios in `test/contract/lockfile-maintenance.contract.test.ts` — the unrelated-pending case and the identical-pending case. The second one pins re-run idempotency and must never be weakened
+- Treat the multi-package footer as part of the idempotency contract
+- Do not claim existing-changeset analysis is PR-scoped. It is still a directory scan, and that remains an open design question — summary comparison reduces the blast radius, it does not fix scoping
+
+## Related Issues
+
+- [Release propagation walked the dependency graph backwards](./release-propagation-walked-dependency-graph-backwards-2026-08-19.md)
+- [Test fixtures underspecified in the dimension the code ignores](../best-practices/test-fixtures-underspecified-in-ignored-dimension-2026-08-19.md)
+- [Contract-first testing for actions that run in foreign repos](../best-practices/contract-testing-actions-that-run-in-foreign-repos-2026-08-19.md)

--- a/docs/solutions/logic-errors/release-propagation-walked-dependency-graph-backwards-2026-08-19.md
+++ b/docs/solutions/logic-errors/release-propagation-walked-dependency-graph-backwards-2026-08-19.md
@@ -1,0 +1,98 @@
+---
+title: Release propagation walked the dependency graph backwards
+date: 2026-08-19
+category: logic-errors
+module: .github/actions/renovate-changesets
+problem_type: logic_error
+component: tooling
+symptoms:
+  - Release PR bumped a package that consumed nothing in the update
+  - Package with no release history gained a first-ever CHANGELOG entry
+  - Changesets CLI stayed green because an over-broad release set is legal input
+root_cause: logic_error
+resolution_type: code_fix
+severity: critical
+related_components:
+  - development_workflow
+tags:
+  - renovate-changesets
+  - changesets
+  - dependency-graph
+  - monorepo
+  - release-automation
+---
+
+## Problem
+
+`findRelatedPackages` treated package relationships as traversable in both directions. That is wrong for release membership.
+
+`analyzeInternalDependencies` records `{source: consumer, target: provider}` — a package that declares `shared` produces `source: gateway`, `target: shared` (`src/multi-package/relationship-analyzer.ts:37-59`). Walking `source → target` after a consumer changed therefore selected the **provider**. The action was answering "what does this package consume?" and using the answer as Changesets release frontmatter.
+
+Propagation was removed in `9ee029e7`. `determineAffectedPackages` now stops at changed files and packages declaring changed external dependencies (`src/multi-package/impact-analyzer.ts:4-34`).
+
+## Symptoms
+
+A dependency update under `apps/gateway` pulled `@marcusrbrown/infra-shared` into the release set even though shared consumed nothing that changed.
+
+The fixture makes the direction explicit:
+
+- `apps/gateway/package.json` declares `@marcusrbrown/infra-shared` and receives `@aws-sdk/client-s3`
+- `packages/shared/package.json` declares only `yaml` and `zod`
+
+In production, `marcusrbrown/infra`'s release PR added `@marcusrbrown/infra-shared` — a package with no release history in that repo, where every prior release bumped `packages/cli` alone. The generating PR updated three AWS SDK packages; shared consumed none of them.
+
+## What Didn't Work
+
+**Reversing the traversal to `target → source`.** That fixes the direction error and preserves the wrong abstraction.
+
+`affectedPackages` is not an impact report. `run-generation.ts` filters it into releasable packages and passes it to changeset generation — it _becomes_ release membership.
+
+Changesets already propagates internal releases when `.changeset/config.json` sets `"updateInternalDependencies": "patch"`, and does it **transitively**: a changeset naming only `c` in an `a → b → c` chain releases `c`, `b`, and `a`. Runtime, optional, and peer dependents participate; dev-only dependents do not.
+
+The action's traversal wasn't even doing that job. It snapshotted the affected set and expanded exactly **one** hop — directionally wrong and semantically incomplete.
+
+## Solution
+
+Propagation was removed entirely: 27 deletions across `src/multi-package-analyzer.ts` (1) and `src/multi-package/impact-analyzer.ts` (26), with no replacement traversal.
+
+`determineAffectedPackages` now has two responsibilities:
+
+1. Add the package owning each changed file (`impact-analyzer.ts:11-16`)
+2. Add packages declaring a changed external dependency, across runtime, dev, peer, and optional maps (`impact-analyzer.ts:18-30`)
+
+`performImpactAnalysis` was deliberately left intact (`impact-analyzer.ts:36-90`). It computes reporting fields — direct vs indirect impact, risk. Impact reporting and release membership are different questions and should not share a code path.
+
+Five unit tests asserted the old behavior and were corrected. In every one, the fixture showed the removed package consumed nothing that changed.
+
+## Why This Works
+
+The action emits only packages identified by a changed path or a dependency declaration. Changesets owns dependent propagation, including transitivity and dependency-type rules.
+
+The contract test verifies the boundary from both sides:
+
+```ts
+expect(authoredReleases(oracle.releasePlan).map(({name}) => name)).toEqual([
+  '@marcusrbrown/infra-gateway',
+])
+expect(effectiveReleases(oracle.releasePlan).map(({name}) => name)).toEqual([
+  '@marcusrbrown/infra-gateway',
+])
+```
+
+Both assertions are necessary. **The Changesets CLI oracle stays green for an over-broad release set** — extra releases are legal input, so the CLI cannot detect that the action selected an unchanged provider. Release-membership assertion is the only gate for this class.
+
+## Prevention
+
+- Treat relationship records as directed declarations: `source` declares a dependency on `target` (`relationship-analyzer.ts:44-59`)
+- Keep release selection separate from impact analysis
+- Do not add local graph propagation unless the action is intentionally replacing Changesets' release algorithm
+- Preserve `test/contract/release-propagation-direction.contract.test.ts`
+- Assert **both** authored and effective release membership. Checking only that Changesets accepts the output is insufficient
+- When changing dependency analysis, verify runtime/optional/peer/dev-only behavior against Changesets rather than inferring release semantics from the relationship graph
+
+## Related Issues
+
+- [Changeset deduplication compared release sets but not summaries](./changeset-dedup-ignored-summaries-2026-08-19.md)
+- [Contract-first testing for actions that run in foreign repos](../best-practices/contract-testing-actions-that-run-in-foreign-repos-2026-08-19.md)
+- [Test fixtures underspecified in the dimension the code ignores](../best-practices/test-fixtures-underspecified-in-ignored-dimension-2026-08-19.md)
+- [renovate-changesets fix workflow](../process/renovate-changesets-fix-workflow.md)

--- a/docs/solutions/process/renovate-changesets-fix-workflow.md
+++ b/docs/solutions/process/renovate-changesets-fix-workflow.md
@@ -29,7 +29,7 @@ git checkout -b fix/renovate-changesets-<brief-description>
 # 2. Edit source in .github/actions/renovate-changesets/src/
 
 # 3. Verify
-pnpm run type-check && pnpm -w test --project renovate-changesets && pnpm run fix && pnpm run lint
+pnpm run type-check && pnpm -w test --project renovate-changesets && pnpm -w test --project renovate-changesets-contract && pnpm run fix && pnpm run lint
 
 # 4. Build dist
 pnpm build
@@ -116,6 +116,11 @@ pnpm run type-check
 # Tests (baseline: check current count before your changes)
 pnpm -w test --project renovate-changesets
 
+# Consumer contract tests — real run() against a consumer-shaped workspace,
+# validated by the real Changesets CLI. Unit tests cannot catch consumer-repo
+# assumption drift; this project is what does.
+pnpm -w test --project renovate-changesets-contract
+
 # Auto-fix lint issues BEFORE checking lint (lint-staged does this on commit too)
 pnpm run fix
 
@@ -128,6 +133,8 @@ Or the all-in-one:
 ```bash
 pnpm run quality-check    # type-check + lint + build + test
 ```
+
+Any change to extraction, grouping, or release selection needs a contract scenario, not another mocked unit test — see [Contract-first testing for actions that run in foreign repos](../best-practices/contract-testing-actions-that-run-in-foreign-repos-2026-08-19.md). Prove it RED against unmodified `src/` before shipping.
 
 ### 6. Build dist
 
@@ -236,3 +243,7 @@ After merging a fix, existing Renovate PRs still reference the old action SHA. T
 - [Root AGENTS.md](/AGENTS.md) — project-wide conventions, commands
 - [Changesets instructions](/.github/instructions/changesets.instructions.md) — changeset creation guidelines
 - [GitHub Actions instructions](/.github/instructions/github-actions.instructions.md) — workflow best practices
+- [Contract-first testing for actions that run in foreign repos](../best-practices/contract-testing-actions-that-run-in-foreign-repos-2026-08-19.md) — why local gates missed six production failures, and the harness that replaced them
+- [Test fixtures underspecified in the dimension the code ignores](../best-practices/test-fixtures-underspecified-in-ignored-dimension-2026-08-19.md) — the fixture pattern that let wrong expectations pass review
+- [Release propagation walked the dependency graph backwards](../logic-errors/release-propagation-walked-dependency-graph-backwards-2026-08-19.md)
+- [Changeset deduplication compared release sets but not summaries](../logic-errors/changeset-dedup-ignored-summaries-2026-08-19.md)


### PR DESCRIPTION
Four entries from the `renovate-changesets` 0.2.35–0.2.43 repair campaign, plus a correction to the fix workflow's verify sequence.

## Why

Every production failure in that campaign shared one shape: an assumption true inside `bfra-me/.github` and false inside a consumer repo. The action is developed here but runs in `marcusrbrown/infra`, and the release gate only ever checked the local environment. These entries capture what that cost and what replaced it.

## What's here

**`best-practices/contract-testing-actions-that-run-in-foreign-repos`** — the durable one. Why local `type-check → test → lint → build` was never sufficient, and how the contract harness works: real `run()`, real temp workspace from a deliberately hostile fixture, real `@changesets/cli` as the final oracle, and a boundary mock that throws on undeclared git commands so drift fails loudly.

**`best-practices/test-fixtures-underspecified-in-ignored-dimension`** — a pattern that recurred four times and passed review every time. A fixture left vague in exactly the dimension the code currently ignores becomes load-bearing the moment the code starts caring, and until then the test encodes the bug it was meant to guard. Includes a six-question checklist for spotting it.

**`logic-errors/release-propagation-walked-dependency-graph-backwards`** — relationships are `{source: consumer, target: provider}`, so walking `source → target` selected the provider when its consumer changed. The fix was removing propagation entirely, not reversing it: Changesets already does this transitively via `updateInternalDependencies`. Notes that the Changesets CLI oracle stays green either way, so release-membership assertions are the only gate for this class.

**`logic-errors/changeset-dedup-ignored-summaries`** — deduplication compared release sets but never summaries, so an unrelated pending changeset silently swallowed a real one and a lockfile entry vanished from the changelog. Also records the new coupling: re-run idempotency now depends on the generated summary being byte-deterministic, footer included.

## Workflow doc correction

`process/renovate-changesets-fix-workflow.md` documented the verify sequence as `type-check → test --project renovate-changesets → fix → lint` — omitting the contract project entirely. That is the exact gate that let six production failures through, so it is now listed in both the quick reference and the expanded step.

No changeset: documentation only, no package behavior change.